### PR TITLE
Fixed scrollbar cutoff issue with auth

### DIFF
--- a/src/framework/auth/components/auth.component.scss
+++ b/src/framework/auth/components/auth.component.scss
@@ -1,6 +1,3 @@
-:host flex-centered {
-  margin: auto;
-}
 :host /deep/ {
   $auth-layout-padding: 2.5rem;
 
@@ -15,7 +12,9 @@
   nb-card {
     margin: 0;
   }
-
+  .flex-centered {
+      margin: auto;
+  }
   nb-card-body {
     display: flex;
   }

--- a/src/framework/auth/components/auth.component.scss
+++ b/src/framework/auth/components/auth.component.scss
@@ -1,3 +1,6 @@
+:host flex-centered {
+  margin: auto;
+}
 :host /deep/ {
   $auth-layout-padding: 2.5rem;
 
@@ -15,8 +18,6 @@
 
   nb-card-body {
     display: flex;
-    align-items: center;
-    justify-content: center;
   }
 
   // TODO rewrite when develop responsive

--- a/src/framework/auth/components/auth.component.ts
+++ b/src/framework/auth/components/auth.component.ts
@@ -14,7 +14,7 @@ import { NbAuthService } from '../services/auth.service';
       <nb-layout-column>
         <nb-card>
           <nb-card-body>
-            <div class="col-xl-4 col-lg-6 col-md-8 col-sm-12">
+            <div class="flex-centered col-xl-4 col-lg-6 col-md-8 col-sm-12">
               <router-outlet></router-outlet>
             </div>
           </nb-card-body>


### PR DESCRIPTION
Currently, if your auth pages get too long, you will start to notice content being cutoff from the page and beyond the scrollbar's range.
![content cutoff](https://i.imgur.com/L0lvfz5.png)

This fix removed the justify-content: center and align-items: center from the auth component's SCSS file and adds a margin: auto to the nb-card-body so that it can remain centered. This fix is coming after hours of researching ending up here:
[https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container](https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container)