### PR TITLE
refactor(context-menu): add tag which will be passed to the inner NbMenu

### DIFF
--- a/docs/output.json
+++ b/docs/output.json
@@ -2023,6 +2023,15 @@
           "required": null,
           "name": "nbContextMenuPlacement",
           "shortDescription": "Position will be calculated relatively host element based on the placement.\nCan be top, right, bottom and left."
+        },
+        {
+          "kind": "input",
+          "platform": null,
+          "isStatic": false,
+          "type": "string",
+          "required": null,
+          "name": "nbContextMenuTag",
+          "shortDescription": "Set NbMenu tag, which helps identify menu when working with NbMenuService."
         }
       ],
       "methods": [

--- a/src/framework/theme/components/context-menu/context-menu.component.ts
+++ b/src/framework/theme/components/context-menu/context-menu.component.ts
@@ -19,10 +19,13 @@ import { NbMenuItem } from '../../';
 @Component({
   selector: 'nb-context-menu',
   styleUrls: ['./context-menu.component.scss'],
-  template: '<nb-menu class="context-menu" [items]="items"></nb-menu>',
+  template: '<nb-menu class="context-menu" [items]="items" [tag]="tag"></nb-menu>',
 })
 export class NbContextMenuComponent {
 
   @Input()
   items: NbMenuItem[] = [];
+
+  @Input()
+  tag: string;
 }

--- a/src/framework/theme/components/context-menu/context-menu.directive.ts
+++ b/src/framework/theme/components/context-menu/context-menu.directive.ts
@@ -55,7 +55,7 @@ export class NbContextMenuDirective implements OnInit, OnDestroy {
   @Input('nbContextMenu')
   set items(items: NbMenuItem[]) {
     this.validateItems(items);
-    this.popover.context = { items };
+    this.popover.context = Object.assign(this.context, { items });
   };
 
   /**
@@ -77,7 +77,16 @@ export class NbContextMenuDirective implements OnInit, OnDestroy {
     this.popover.adjustment = adjustment;
   }
 
+  /**
+   * Set NbMenu tag, which helps identify menu when working with NbMenuService.
+   * */
+  @Input('nbContextMenuTag')
+  set tag(tag: string) {
+    this.popover.context = Object.assign(this.context, { tag });
+  }
+
   protected popover: NbPopoverDirective;
+  protected context = {};
 
   constructor(hostRef: ElementRef,
               themeService: NbThemeService,


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Add capability pass NbMenu tag through NbContextMenu