### PR TITLE
Set Authorization header only if the token is valid

### DIFF
--- a/src/framework/auth/services/interceptors/jwt-interceptor.ts
+++ b/src/framework/auth/services/interceptors/jwt-interceptor.ts
@@ -17,7 +17,7 @@ export class NbAuthJWTInterceptor implements HttpInterceptor {
     return this.authService.getToken()
       .pipe(
         switchMap((token: NbAuthJWTToken) => {
-          if (token) {
+          if (token.isValid()) {
             const JWT = `Bearer ${token.getValue()}`;
             req = req.clone({
               setHeaders: {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Solves an issue where the header is set in the interceptor even if we don't have any token.
Solves issue #293 
