### PR TITLE
refactor(auth): pass providers through special `install` method for b…

### DIFF
--- a/docs/articles/auth-install.md
+++ b/docs/articles/auth-install.md
@@ -8,7 +8,7 @@
 ## Installation steps
 
 1) First, let's install the module as it's distributed as an npm package, but make sure you have the [Nebular Theme module up and running](https://akveo.github.io/nebular/#/docs/installation/add-into-existing-project).
-Nebular Theme is required to use built-in Auth Components. If you are not going to use those at all, you can use `Auth Module` without `Nebular Theme`. 
+Nebular Theme is required to use built-in Auth Components. If you are not going to use those at all, you can use `Auth Module` without the `Nebular Theme` module. 
 
 Let's assume that we need to setup email & password authentication based on Nebular Auth and NbEmailPassAuthProvider.
 
@@ -18,7 +18,7 @@ Let's assume that we need to setup email & password authentication based on Nebu
 
 `import { NbEmailPassAuthProvider, NbAuthModule } from '@nebular/auth';`
 
-3) Now, let's configure the module by specifying available providers, in your case we add `NbEmailPassAuthProvider`:
+3) Now, let's configure the module by specifying available providers, in our case we add `NbEmailPassAuthProvider`:
 
 ```typescript
 
@@ -28,7 +28,7 @@ Let's assume that we need to setup email & password authentication based on Nebu
     
    NbAuthModule.forRoot({
      providers: [
-       NbEmailPassAuthProvider.install('email', { ... }),
+       NbEmailPassAuthProvider.register('email', { ... }),
      ],
      forms: {},
    }), 
@@ -37,7 +37,8 @@ Let's assume that we need to setup email & password authentication based on Nebu
 
 ```
 
-We also specified a `forms` key, which configures available options for the Auth Components. We'll leave it empty for now and get back to it in the [Configuring UI](#/docs/auth/configuring-ui) article.
+We also specified a `forms` key, which configures available options for the Auth Components. 
+We leave it empty for now and get back to it in the [Configuring UI](#/docs/auth/configuring-ui) article.
 
 4) Next, we need to configure Auth Components routes, let's add those into your `app-routing.module.ts`:
 

--- a/docs/articles/auth-install.md
+++ b/docs/articles/auth-install.md
@@ -27,16 +27,11 @@ Let's assume that we need to setup email & password authentication based on Nebu
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
-           email: {
-             service: NbEmailPassAuthProvider,
-             config: {
-              ...
-             },
-           },
-         },
-         forms: {},
-       }), 
+     providers: [
+       NbEmailPassAuthProvider.install('email', { ... }),
+     ],
+     forms: {},
+   }), 
   ],
 });
 

--- a/docs/articles/auth-provider.md
+++ b/docs/articles/auth-provider.md
@@ -24,15 +24,10 @@ We assume you already have the Auth module installed inside of your `*.module.ts
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
-           email: {
-             service: NbEmailPassAuthProvider,
-             config: {
-              ...
-             },
-           },
-         },
-       }), 
+     providers: [
+       NbEmailPassAuthProvider.install('email', { ... }),
+     ],
+   }),
   ],
 });
 
@@ -41,28 +36,31 @@ We assume you already have the Auth module installed inside of your `*.module.ts
 Now, let's add API endpoints. According to the [NbEmailPassAuthProvider documentation](#/docs/auth/nbemailpassauthprovider), we have `baseEndpoint` setting, and also an `endpoint` setting for each function (login/register/etc):
 
 ```typescript
-{
- ...
- baseEndpoint: '',
- login: {
-   ...
-   endpoint: '/api/auth/login',
-   ...
- },
- register: {
-   ...
-   endpoint: '/api/auth/register',
-   ...
- },
+
+// ...
+
+NbAuthModule.forRoot({
+  providers: [
+    NbEmailPassAuthProvider.install('email', {
+      baseEndpoint: '',
+      login: {
+        endpoint: '/api/auth/login',
+      },
+      register: {
+        endpoint: '/api/auth/register',
+      },
+    }),
+  ],
+}),
 ```
 
 Let's assume that our API is localed on a separate server `http://example.com/app-api/v1` and change the `baseEndpoint` accordingly:
 
 ```typescript
 {
- ...
- baseEndpoint: 'http://example.com/app-api/v1',
- ...
+ // ...
+  baseEndpoint: 'http://example.com/app-api/v1',
+ // ...
 }
 ```
 
@@ -70,14 +68,14 @@ And configure the endpoints, considering that the final endpoint will consist of
 
 ```typescript
 {
- baseEndpoint: 'http://example.com/app-api/v1',
- login: {
-   endpoint: '/auth/sign-in',
- },
- register: {
-   endpoint: '/auth/sign-up',
- },
- logout: {
+  baseEndpoint: 'http://example.com/app-api/v1',
+  login: {
+    endpoint: '/auth/sign-in',
+  },
+  register: {
+    endpoint: '/auth/sign-up',
+  },
+  logout: {
     endpoint: '/auth/sign-out',
   },
   requestPass: {
@@ -93,16 +91,16 @@ Finally, let's presume that unlike in the default provider settings, our API acc
 
 ```typescript
 {
- baseEndpoint: 'http://example.com/app-api/v1',
- login: {
-   endpoint: '/auth/sign-in',
-   method: 'post',
- },
- register: {
-   endpoint: '/auth/sign-up',
-   method: 'post',
- },
- logout: {
+  baseEndpoint: 'http://example.com/app-api/v1',
+  login: {
+    endpoint: '/auth/sign-in',
+    method: 'post',
+  },
+  register: {
+    endpoint: '/auth/sign-up',
+    method: 'post',
+  },
+  logout: {
     endpoint: '/auth/sign-out',
     method: 'post',
   },

--- a/docs/articles/auth-provider.md
+++ b/docs/articles/auth-provider.md
@@ -25,13 +25,17 @@ We assume you already have the Auth module installed inside of your `*.module.ts
     
    NbAuthModule.forRoot({
      providers: [
-       NbEmailPassAuthProvider.install('email', { ... }),
+       NbEmailPassAuthProvider.register('email', { ... }),
      ],
    }),
   ],
 });
 
 ```
+
+`email` here is an alias we assign to the provider, so that we can mention it later on dynamically. Plus we can configure multiple providers with various configurations
+under different names. Then we can use then separately, if that's the case.
+`{ ... }` is a configuration we provide, such as API endpoints, token extractors, etc.
 
 Now, let's add API endpoints. According to the [NbEmailPassAuthProvider documentation](#/docs/auth/nbemailpassauthprovider), we have `baseEndpoint` setting, and also an `endpoint` setting for each function (login/register/etc):
 
@@ -41,7 +45,7 @@ Now, let's add API endpoints. According to the [NbEmailPassAuthProvider document
 
 NbAuthModule.forRoot({
   providers: [
-    NbEmailPassAuthProvider.install('email', {
+    NbEmailPassAuthProvider.register('email', {
       baseEndpoint: '',
       login: {
         endpoint: '/api/auth/login',

--- a/docs/articles/auth-token.md
+++ b/docs/articles/auth-token.md
@@ -42,19 +42,16 @@ We'll assume that our API returns a token as just `{token: 'some-jwt-token'}` no
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
-           email: {
-             service: NbEmailPassAuthProvider,
-             config: {
-               ...
-                
-               token: {
-                 key: 'token', // this parameter tells Nebular where to look for the token
-               },
-             },
-           },
+     providers: [
+       NbEmailPassAuthProvider.install('email', {
+         ...
+        
+         token: {
+           key: 'token', // this parameter tells Nebular where to look for the token
          },
-       }), 
+       }),
+     ],
+   }), 
   ],
 });
 ```  

--- a/docs/articles/auth-token.md
+++ b/docs/articles/auth-token.md
@@ -6,25 +6,28 @@ you have successfully configured an auth provider and adjusted auth look & fell 
 It's time to get a user token after successful authentication to be able to communicate with the server and, for instance, show a username in the header of the application.
 Let's assume that your backend returns a JWT token so that we can use the token payload to extract a user info out of it.
 
-1) Firstly, let's tell Nebular that we are waiting for JWT token, to do that we just need to provide a respective class. Open your `app.module.ts` and add the following:
+Each provider specifies which token class it's going to use by default. For example, `NbEmailPassAuthProvider` uses `NbAuthSimpleToken`, 
+and `NbOAuth2AuthProvider` uses `NbAuthOAuth2Token`. But it is also possible to specify another token class if we want.
+
+1) Let's tell Nebular that we are waiting for a JWT token, to do that we just need to provide a respective class. Open your `app.module.ts` and adjust the provider configuration:
 
 ```typescript
 
-import { NB_AUTH_TOKEN_CLASS, NbAuthJWTToken } from '@nebular/auth';
+import { NbAuthJWTToken } from '@nebular/auth';
 
 @NgModule({
   imports: [ ... ].
   
   providers: [
-    ...
-    { provide: NB_AUTH_TOKEN_CLASS, useValue: NbAuthJWTToken },
+    // ...
+    NbEmailPassAuthProvider.register('email', { ... }, NbAuthJWTToken),
   ],
 });
 
 ```
-This line tells Angular to inject `NbAuthJWTToken` (instead of the default `NbAuthSimpleToken`) which is a wrapper class around a value your API service returns.
+Provider's register method accepts a token class as a third parameter.
 
-2) Then, let's configure where Nebular should look for the token in the login/register response data. By default Nebular expects that your token is located under the `data.token` keys of the JSON response:
+2) Then, let's configure where `NbEmailPassAuthProvider` should look for the token in the login/register response data. By default `NbEmailPassAuthProvider` expects that your token is located under the `data.token` keys of the JSON response:
 
 ```typescript
 {
@@ -43,13 +46,13 @@ We'll assume that our API returns a token as just `{token: 'some-jwt-token'}` no
     
    NbAuthModule.forRoot({
      providers: [
-       NbEmailPassAuthProvider.install('email', {
+       NbEmailPassAuthProvider.register('email', {
          ...
         
          token: {
-           key: 'token', // this parameter tells Nebular where to look for the token
+           key: 'token', // this parameter tells where to look for the token
          },
-       }),
+       }, NbAuthJWTToken),
      ],
    }), 
   ],
@@ -95,7 +98,7 @@ export class HeaderComponent {
     this.authService.onTokenChange()
       .subscribe((token: NbAuthJWTToken) => {
       
-        if (token.isValid()) {
+        if (token.isValid()) { // if have to check if the token is valid
           this.user = token.getPayload(); // here we receive a payload from the token and assigne it to our `user` variable 
         }
         
@@ -105,7 +108,7 @@ export class HeaderComponent {
 }
 ```
 
-6) Lastly, let's grad a `user` variable and put it in the template to show the user info. The `nb-user` component is a great fit for this:
+6) Lastly, let's grab a `user` variable and put it in the template to show the user info. The `nb-user` component is a great fit for this:
 
 
 ```typescript

--- a/docs/articles/auth-ui.md
+++ b/docs/articles/auth-ui.md
@@ -18,19 +18,14 @@ Alongside with the provider's configuration `AuthModule` also accepts a list of 
 
 @NgModule({
   imports: [
-   // ...
+    // ...
     
-   NbAuthModule.forRoot({
-         providers: {
-           email: {
-             service: NbEmailPassAuthProvider,
-             config: {
-              ...
-             },
-           },
-         },
-         forms: {},
-       }), 
+    NbAuthModule.forRoot({
+      providers: [
+        NbEmailPassAuthProvider.install('email', { ... }),
+      ],
+      forms: {},
+    }), 
   ],
 });
 
@@ -121,45 +116,40 @@ So, for instance, to remove the redirectDelay setting and disable the success me
   imports: [
    // ...
     
-   NbAuthModule.forRoot({
-         providers: {
-           email: {
-             service: NbEmailPassAuthProvider,
-             config: {
-              ...
-             },
-           },
-         },
-         forms: {
-          login: {
-            redirectDelay: 0,
-            showMessages: {
-              success: true,
-            },
-          },
-          register: {
-            redirectDelay: 0,
-            showMessages: {
-              success: true,
-            },
-          },
-          requestPassword: {
-            redirectDelay: 0,
-            showMessages: {
-              success: true,
-            },
-          },
-          resetPassword: {
-            redirectDelay: 0,
-            showMessages: {
-              success: true,
-            },
-          },
-          logout: {
-            redirectDelay: 0,
+  NbAuthModule.forRoot({
+       providers: [
+         NbEmailPassAuthProvider.install('email', { ... }),
+       ],
+       forms: {
+        login: {
+          redirectDelay: 0,
+          showMessages: {
+            success: true,
           },
         },
-     }), 
+        register: {
+          redirectDelay: 0,
+          showMessages: {
+            success: true,
+          },
+        },
+        requestPassword: {
+          redirectDelay: 0,
+          showMessages: {
+            success: true,
+          },
+        },
+        resetPassword: {
+          redirectDelay: 0,
+          showMessages: {
+            success: true,
+          },
+        },
+        logout: {
+          redirectDelay: 0,
+        },
+      },
+   }), 
   ],
 });
 
@@ -181,24 +171,19 @@ const formSetting: any = {
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
-           email: {
-             service: NbEmailPassAuthProvider,
-             config: {
-              ...
-             },
-           },
+       providers: [
+         NbEmailPassAuthProvider.install('email', { ... }),
+       ],
+       forms: {
+         login: formSetting,
+         register: formSetting,
+         requestPassword: formSetting,
+         resetPassword: formSetting,
+         logout: {
+           redirectDelay: 0,
          },
-         forms: {
-          login: formSetting,
-          register: formSetting,
-          requestPassword: formSetting,
-          resetPassword: formSetting,
-          logout: {
-            redirectDelay: 0,
-          },
-        },
-     }), 
+       },
+   }),
   ],
 });
 

--- a/docs/articles/auth-ui.md
+++ b/docs/articles/auth-ui.md
@@ -22,7 +22,7 @@ Alongside with the provider's configuration `AuthModule` also accepts a list of 
     
     NbAuthModule.forRoot({
       providers: [
-        NbEmailPassAuthProvider.install('email', { ... }),
+        NbEmailPassAuthProvider.register('email', { ... }),
       ],
       forms: {},
     }), 
@@ -118,7 +118,7 @@ So, for instance, to remove the redirectDelay setting and disable the success me
     
   NbAuthModule.forRoot({
        providers: [
-         NbEmailPassAuthProvider.install('email', { ... }),
+         NbEmailPassAuthProvider.register('email', { ... }),
        ],
        forms: {
         login: {
@@ -172,7 +172,7 @@ const formSetting: any = {
     
    NbAuthModule.forRoot({
        providers: [
-         NbEmailPassAuthProvider.install('email', { ... }),
+         NbEmailPassAuthProvider.register('email', { ... }),
        ],
        forms: {
          login: formSetting,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -166,46 +166,40 @@ const NB_TEST_COMPONENTS = [
           ],
         },
       },
-      providers: {
-        //
-        // email: {
-        //   service: NbDummyAuthProvider,
-        //   config: {
-        //     alwaysFail: true,
-        //     delay: 1000,
-        //   },
-        // },
-        email: {
-          service: NbEmailPassAuthProvider,
-          config: {
-            login: {
-              endpoint: 'http://localhost:4400/api/auth/login',
-            },
-            register: {
-              endpoint: 'http://localhost:4400/api/auth/register',
-            },
-            logout: {
-              endpoint: 'http://localhost:4400/api/auth/logout',
-              redirect: {
-                success: '/auth/login',
-                failure: '/auth/login',
-              },
-            },
-            requestPass: {
-              endpoint: 'http://localhost:4400/api/auth/request-pass',
-              redirect: {
-                success: '/auth/reset-password',
-              },
-            },
-            resetPass: {
-              endpoint: 'http://localhost:4400/api/auth/reset-pass',
-              redirect: {
-                success: '/auth/login',
-              },
+      providers: [
+        // NbDummyAuthProvider.install('email', {
+        //   alwaysFail: true,
+        //   delay: 1000,
+        // }),
+
+        NbEmailPassAuthProvider.install('email', {
+          login: {
+            endpoint: 'http://localhost:4400/api/auth/login',
+          },
+          register: {
+            endpoint: 'http://localhost:4400/api/auth/register',
+          },
+          logout: {
+            endpoint: 'http://localhost:4400/api/auth/logout',
+            redirect: {
+              success: '/auth/login',
+              failure: '/auth/login',
             },
           },
-        },
-      },
+          requestPass: {
+            endpoint: 'http://localhost:4400/api/auth/request-pass',
+            redirect: {
+              success: '/auth/reset-password',
+            },
+          },
+          resetPass: {
+            endpoint: 'http://localhost:4400/api/auth/reset-pass',
+            redirect: {
+              success: '/auth/login',
+            },
+          },
+        }),
+      ],
     }),
     NbSecurityModule.forRoot({
       accessControl: {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,7 +27,6 @@ import {
 } from '@nebular/theme';
 
 import {
-  NB_AUTH_TOKEN_CLASS,
   NbAuthJWTToken,
   NbAuthModule,
   NbEmailPassAuthProvider,
@@ -173,32 +172,33 @@ const NB_TEST_COMPONENTS = [
         // }),
 
         NbEmailPassAuthProvider.register('email', {
+          baseEndpoint: 'http://localhost:4400/api/auth/',
           login: {
-            endpoint: 'http://localhost:4400/api/auth/login',
+            endpoint: 'login',
           },
           register: {
-            endpoint: 'http://localhost:4400/api/auth/register',
+            endpoint: 'register',
           },
           logout: {
-            endpoint: 'http://localhost:4400/api/auth/logout',
+            endpoint: 'logout',
             redirect: {
               success: '/auth/login',
               failure: '/auth/login',
             },
           },
           requestPass: {
-            endpoint: 'http://localhost:4400/api/auth/request-pass',
+            endpoint: 'request-pass',
             redirect: {
               success: '/auth/reset-password',
             },
           },
           resetPass: {
-            endpoint: 'http://localhost:4400/api/auth/reset-pass',
+            endpoint: 'reset-pass',
             redirect: {
               success: '/auth/login',
             },
           },
-        }),
+        }, NbAuthJWTToken),
       ],
     }),
     NbSecurityModule.forRoot({
@@ -226,7 +226,6 @@ const NB_TEST_COMPONENTS = [
   ],
   providers: [
     AuthGuard,
-    { provide: NB_AUTH_TOKEN_CLASS, useValue: NbAuthJWTToken },
     { provide: HTTP_INTERCEPTORS, useClass: NbAuthJWTInterceptor, multi: true },
     { provide: NbRoleProvider, useClass: RoleProvider },
   ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -167,12 +167,12 @@ const NB_TEST_COMPONENTS = [
         },
       },
       providers: [
-        // NbDummyAuthProvider.install('email', {
+        // NbDummyAuthProvider.register('email', {
         //   alwaysFail: true,
         //   delay: 1000,
         // }),
 
-        NbEmailPassAuthProvider.install('email', {
+        NbEmailPassAuthProvider.register('email', {
           login: {
             endpoint: 'http://localhost:4400/api/auth/login',
           },

--- a/src/framework/auth/auth.module.ts
+++ b/src/framework/auth/auth.module.ts
@@ -7,6 +7,8 @@ import { HttpClientModule } from '@angular/common/http';
 import { NbLayoutModule, NbCardModule, NbCheckboxModule } from '@nebular/theme';
 
 import { NbAuthService } from './services/auth.service';
+import { NbDummyAuthProvider } from './providers/dummy-auth.provider';
+import { NbEmailPassAuthProvider } from './providers/email-pass-auth.provider';
 import { NbTokenService } from './services/token/token.service';
 import { NbAuthSimpleToken } from './services/token/token';
 import { NbTokenLocalStorage, NbTokenStorage } from './services/token/token-storage';
@@ -85,13 +87,12 @@ export class NbAuthModule {
         { provide: NB_AUTH_OPTIONS, useFactory: nbOptionsFactory, deps: [NB_AUTH_USER_OPTIONS] },
         { provide: NB_AUTH_TOKEN_CLASS, useValue: NbAuthSimpleToken },
         { provide: NB_AUTH_INTERCEPTOR_HEADER, useValue: 'Authorization' },
-        ...nbAuthOptions.providers.map(([name, providerClass]: [string, any]) => {
-          return providerClass;
-        }),
         { provide: NB_AUTH_PROVIDERS, useFactory: nbProvidersFactory, deps: [NB_AUTH_OPTIONS, Injector] },
         NbAuthService,
         { provide: NbTokenStorage, useClass: NbTokenLocalStorage },
         NbTokenService,
+        NbDummyAuthProvider,
+        NbEmailPassAuthProvider,
       ],
     };
   }

--- a/src/framework/auth/auth.module.ts
+++ b/src/framework/auth/auth.module.ts
@@ -11,7 +11,7 @@ import { NbDummyAuthProvider } from './providers/dummy-auth.provider';
 import { NbEmailPassAuthProvider } from './providers/email-pass-auth.provider';
 import { NbTokenService } from './services/token/token.service';
 import { NbTokenLocalStorage, NbTokenStorage } from './services/token/token-storage';
-import { NbAuthTokenPacker } from './services/token/token-packer';
+import { NbAuthTokenParceler } from './services/token/token-parceler';
 import { NbAbstractAuthProvider } from './providers';
 import {
   defaultSettings,
@@ -99,7 +99,7 @@ export class NbAuthModule {
         { provide: NB_AUTH_PROVIDERS, useFactory: nbProvidersFactory, deps: [NB_AUTH_OPTIONS, Injector] },
         { provide: NB_AUTH_TOKENS, useFactory: nbTokensFactory, deps: [NB_AUTH_OPTIONS] },
         NbAuthService,
-        NbAuthTokenPacker,
+        NbAuthTokenParceler,
         { provide: NbTokenStorage, useClass: NbTokenLocalStorage },
         NbTokenService,
         NbDummyAuthProvider,

--- a/src/framework/auth/auth.module.ts
+++ b/src/framework/auth/auth.module.ts
@@ -7,8 +7,6 @@ import { HttpClientModule } from '@angular/common/http';
 import { NbLayoutModule, NbCardModule, NbCheckboxModule } from '@nebular/theme';
 
 import { NbAuthService } from './services/auth.service';
-import { NbDummyAuthProvider } from './providers/dummy-auth.provider';
-import { NbEmailPassAuthProvider } from './providers/email-pass-auth.provider';
 import { NbTokenService } from './services/token/token.service';
 import { NbAuthSimpleToken } from './services/token/token';
 import { NbTokenLocalStorage, NbTokenStorage } from './services/token/token-storage';
@@ -17,7 +15,7 @@ import {
   NB_AUTH_USER_OPTIONS,
   NB_AUTH_OPTIONS,
   NB_AUTH_PROVIDERS,
-  NbAuthOptions, NB_AUTH_INTERCEPTOR_HEADER, NB_AUTH_TOKEN_CLASS,
+  NbAuthOptions, NB_AUTH_INTERCEPTOR_HEADER, NB_AUTH_TOKEN_CLASS, NbAuthProviders,
 } from './auth.options';
 
 import { NbAuthComponent } from './components/auth.component';
@@ -32,18 +30,17 @@ import { NbResetPasswordComponent } from './components/reset-password/reset-pass
 import { routes } from './auth.routes';
 import { deepExtend } from './helpers';
 
-export function nbAuthServiceFactory(config: any, tokenService: NbTokenService, injector: Injector) {
-  const providers = config.providers || {};
+export function nbProvidersFactory(options: NbAuthOptions, injector: Injector): NbAuthProviders {
+  const providers = {};
 
-  for (const key in providers) {
-    if (providers.hasOwnProperty(key)) {
-      const provider = providers[key];
-      const object = injector.get(provider.service);
-      object.setConfig(provider.config || {});
-    }
-  }
+  options.providers.forEach(([name, providerClass, providerConfig]: [string, any, any]) => {
+    const object = injector.get(providerClass);
+    object.setConfig(providerConfig || {});
 
-  return new NbAuthService(tokenService, injector, providers);
+    providers[name] = providerClass;
+  });
+
+  return providers;
 }
 
 export function nbOptionsFactory(options) {
@@ -86,18 +83,15 @@ export class NbAuthModule {
       providers: [
         { provide: NB_AUTH_USER_OPTIONS, useValue: nbAuthOptions },
         { provide: NB_AUTH_OPTIONS, useFactory: nbOptionsFactory, deps: [NB_AUTH_USER_OPTIONS] },
-        { provide: NB_AUTH_PROVIDERS, useValue: {} },
         { provide: NB_AUTH_TOKEN_CLASS, useValue: NbAuthSimpleToken },
         { provide: NB_AUTH_INTERCEPTOR_HEADER, useValue: 'Authorization' },
-        {
-          provide: NbAuthService,
-          useFactory: nbAuthServiceFactory,
-          deps: [NB_AUTH_OPTIONS, NbTokenService, Injector],
-        },
+        ...nbAuthOptions.providers.map(([name, providerClass]: [string, any]) => {
+          return providerClass;
+        }),
+        { provide: NB_AUTH_PROVIDERS, useFactory: nbProvidersFactory, deps: [NB_AUTH_OPTIONS, Injector] },
+        NbAuthService,
         { provide: NbTokenStorage, useClass: NbTokenLocalStorage },
         NbTokenService,
-        NbDummyAuthProvider,
-        NbEmailPassAuthProvider,
       ],
     };
   }

--- a/src/framework/auth/auth.module.ts
+++ b/src/framework/auth/auth.module.ts
@@ -10,14 +10,15 @@ import { NbAuthService } from './services/auth.service';
 import { NbDummyAuthProvider } from './providers/dummy-auth.provider';
 import { NbEmailPassAuthProvider } from './providers/email-pass-auth.provider';
 import { NbTokenService } from './services/token/token.service';
-import { NbAuthSimpleToken } from './services/token/token';
 import { NbTokenLocalStorage, NbTokenStorage } from './services/token/token-storage';
+import { NbAuthTokenPacker } from './services/token/token-packer';
+import { NbAbstractAuthProvider } from './providers';
 import {
   defaultSettings,
   NB_AUTH_USER_OPTIONS,
   NB_AUTH_OPTIONS,
   NB_AUTH_PROVIDERS,
-  NbAuthOptions, NB_AUTH_INTERCEPTOR_HEADER, NB_AUTH_TOKEN_CLASS, NbAuthProviders,
+  NbAuthOptions, NB_AUTH_INTERCEPTOR_HEADER, NbAuthProviders, NB_AUTH_TOKENS, NbProviderRegister,
 } from './auth.options';
 
 import { NbAuthComponent } from './components/auth.component';
@@ -35,14 +36,23 @@ import { deepExtend } from './helpers';
 export function nbProvidersFactory(options: NbAuthOptions, injector: Injector): NbAuthProviders {
   const providers = {};
 
-  options.providers.forEach(([name, providerClass, providerConfig]: [string, any, any]) => {
-    const object = injector.get(providerClass);
+  options.providers.forEach(([name, providerClass, providerConfig, tokenClass]: NbProviderRegister) => {
+    const object: NbAbstractAuthProvider = injector.get(providerClass);
     object.setConfig(providerConfig || {});
+    object.setTokenClass(tokenClass);
 
     providers[name] = providerClass;
   });
 
   return providers;
+}
+
+export function nbTokensFactory(options: NbAuthOptions): NbAuthProviders {
+  const tokens = {};
+  options.providers.forEach(([, , , tokenClass]: NbProviderRegister) => {
+    tokens[tokenClass.name] = tokenClass;
+  });
+  return tokens;
 }
 
 export function nbOptionsFactory(options) {
@@ -85,10 +95,11 @@ export class NbAuthModule {
       providers: [
         { provide: NB_AUTH_USER_OPTIONS, useValue: nbAuthOptions },
         { provide: NB_AUTH_OPTIONS, useFactory: nbOptionsFactory, deps: [NB_AUTH_USER_OPTIONS] },
-        { provide: NB_AUTH_TOKEN_CLASS, useValue: NbAuthSimpleToken },
         { provide: NB_AUTH_INTERCEPTOR_HEADER, useValue: 'Authorization' },
         { provide: NB_AUTH_PROVIDERS, useFactory: nbProvidersFactory, deps: [NB_AUTH_OPTIONS, Injector] },
+        { provide: NB_AUTH_TOKENS, useFactory: nbTokensFactory, deps: [NB_AUTH_OPTIONS] },
         NbAuthService,
+        NbAuthTokenPacker,
         { provide: NbTokenStorage, useClass: NbTokenLocalStorage },
         NbTokenService,
         NbDummyAuthProvider,

--- a/src/framework/auth/auth.options.ts
+++ b/src/framework/auth/auth.options.ts
@@ -1,5 +1,5 @@
 import { InjectionToken } from '@angular/core';
-import { NbAuthToken } from './services';
+import { NbTokenClass } from './services';
 import { NbAbstractAuthProvider } from './providers';
 
 export interface NbAuthOptions {
@@ -7,9 +7,13 @@ export interface NbAuthOptions {
   providers?: any;
 }
 
+type NbProviderClass = new (...params: any[]) => NbAbstractAuthProvider;
+
 export interface NbAuthProviders {
-  [name: string]: new () => NbAbstractAuthProvider,
+  [name: string]: NbProviderClass,
 }
+
+export type NbProviderRegister = [string, NbProviderClass, { [key: string]: any }, NbTokenClass];
 
 export interface NbAuthSocialLink {
   link?: string,
@@ -87,5 +91,5 @@ export const defaultSettings: any = {
 export const NB_AUTH_OPTIONS = new InjectionToken<NbAuthOptions>('Nebular Auth Options');
 export const NB_AUTH_USER_OPTIONS = new InjectionToken<NbAuthOptions>('Nebular User Auth Options');
 export const NB_AUTH_PROVIDERS = new InjectionToken<NbAuthProviders>('Nebular Auth Providers');
-export const NB_AUTH_TOKEN_CLASS = new InjectionToken<NbAuthToken>('Nebular Token Class');
+export const NB_AUTH_TOKENS = new InjectionToken<NbAuthProviders>('Nebular Auth Tokens');
 export const NB_AUTH_INTERCEPTOR_HEADER = new InjectionToken<NbAuthProviders>('Nebular Simple Interceptor Header');

--- a/src/framework/auth/auth.options.ts
+++ b/src/framework/auth/auth.options.ts
@@ -7,7 +7,7 @@ export interface NbAuthOptions {
   providers?: any;
 }
 
-type NbProviderClass = new (...params: any[]) => NbAbstractAuthProvider;
+export type NbProviderClass = new (...params: any[]) => NbAbstractAuthProvider;
 
 export interface NbAuthProviders {
   [name: string]: NbProviderClass,

--- a/src/framework/auth/auth.options.ts
+++ b/src/framework/auth/auth.options.ts
@@ -1,5 +1,6 @@
 import { InjectionToken } from '@angular/core';
 import { NbAuthToken } from './services';
+import { NbAbstractAuthProvider } from './providers';
 
 export interface NbAuthOptions {
   forms?: any;
@@ -7,7 +8,7 @@ export interface NbAuthOptions {
 }
 
 export interface NbAuthProviders {
-  [key: string]: any;
+  [name: string]: new () => NbAbstractAuthProvider,
 }
 
 export interface NbAuthSocialLink {
@@ -21,6 +22,7 @@ export interface NbAuthSocialLink {
 const socialLinks: NbAuthSocialLink[] = [];
 
 export const defaultSettings: any = {
+  providers: [],
   forms: {
     login: {
       redirectDelay: 500, // delay before redirect after a successful login, while success message is shown to the user

--- a/src/framework/auth/components/auth.component.ts
+++ b/src/framework/auth/components/auth.component.ts
@@ -27,16 +27,12 @@ import { takeWhile } from 'rxjs/operators/takeWhile';
 export class NbAuthComponent implements OnDestroy {
 
   private alive = true;
-
-  subscription: any;
-
   authenticated: boolean = false;
-  token: string = '';
 
   // showcase of how to use the onAuthenticationChange method
   constructor(protected auth: NbAuthService) {
 
-    this.subscription = auth.onAuthenticationChange()
+    auth.onAuthenticationChange()
       .pipe(takeWhile(() => this.alive))
       .subscribe((authenticated: boolean) => {
         this.authenticated = authenticated;

--- a/src/framework/auth/providers/abstract-auth.provider.ts
+++ b/src/framework/auth/providers/abstract-auth.provider.ts
@@ -1,16 +1,25 @@
 import { HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Rx';
-import { NbAuthResult } from '../services/auth-result';
 
+import { NbAuthResult, nbCreateToken, NbTokenClass } from '../services';
 import { deepExtend, getDeepFromObject } from '../helpers';
 
 export abstract class NbAbstractAuthProvider {
 
   protected defaultConfig: any = {};
   protected config: any = {};
+  protected tokenClass: NbTokenClass;
 
   setConfig(config: any): void {
     this.config = deepExtend({}, this.defaultConfig, config);
+  }
+
+  setTokenClass(tokenClass: NbTokenClass): void {
+    this.tokenClass = tokenClass;
+  }
+
+  createToken(rawValue: string) {
+    return nbCreateToken(this.tokenClass, rawValue);
   }
 
   getConfigValue(key: string): any {

--- a/src/framework/auth/providers/abstract-auth.provider.ts
+++ b/src/framework/auth/providers/abstract-auth.provider.ts
@@ -1,7 +1,7 @@
 import { HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Rx';
 
-import { NbAuthResult, nbCreateToken, NbTokenClass } from '../services';
+import { NbAuthToken, NbAuthResult, nbCreateToken, NbTokenClass } from '../services';
 import { deepExtend, getDeepFromObject } from '../helpers';
 
 export abstract class NbAbstractAuthProvider {
@@ -18,7 +18,7 @@ export abstract class NbAbstractAuthProvider {
     this.tokenClass = tokenClass;
   }
 
-  createToken(rawValue: string) {
+  createToken(rawValue: string): NbAuthToken {
     return nbCreateToken(this.tokenClass, rawValue);
   }
 

--- a/src/framework/auth/providers/dummy-auth.provider.ts
+++ b/src/framework/auth/providers/dummy-auth.provider.ts
@@ -19,7 +19,7 @@ export class NbDummyAuthProvider extends NbAbstractAuthProvider {
     delay: 1000,
   };
 
-  static install(name: string, config: NbDummyAuthProviderConfig) {
+  static register(name: string, config: NbDummyAuthProviderConfig) {
     return [name, NbDummyAuthProvider, config];
   }
 

--- a/src/framework/auth/providers/dummy-auth.provider.ts
+++ b/src/framework/auth/providers/dummy-auth.provider.ts
@@ -19,6 +19,10 @@ export class NbDummyAuthProvider extends NbAbstractAuthProvider {
     delay: 1000,
   };
 
+  static install(name: string, config: NbDummyAuthProviderConfig) {
+    return [name, NbDummyAuthProvider, config];
+  }
+
   authenticate(data?: any): Observable<NbAuthResult> {
     return observableOf(this.createDummyResult(data))
       .pipe(

--- a/src/framework/auth/providers/dummy-auth.provider.ts
+++ b/src/framework/auth/providers/dummy-auth.provider.ts
@@ -5,7 +5,8 @@ import { of as observableOf } from 'rxjs/observable/of';
 import { delay } from 'rxjs/operators/delay';
 
 import { NbAbstractAuthProvider } from './abstract-auth.provider';
-import { NbAuthResult } from '../services/auth-result';
+import { NbAuthResult, NbAuthSimpleToken, NbTokenClass } from '../services';
+import { NbProviderRegister } from '../auth.options';
 
 export interface NbDummyAuthProviderConfig {
   delay?: number;
@@ -19,8 +20,10 @@ export class NbDummyAuthProvider extends NbAbstractAuthProvider {
     delay: 1000,
   };
 
-  static register(name: string, config: NbDummyAuthProviderConfig) {
-    return [name, NbDummyAuthProvider, config];
+  static register(name: string,
+                  config: NbDummyAuthProviderConfig,
+                  token: NbTokenClass = NbAuthSimpleToken): NbProviderRegister {
+    return [name, NbDummyAuthProvider, config, token];
   }
 
   authenticate(data?: any): Observable<NbAuthResult> {
@@ -67,7 +70,11 @@ export class NbDummyAuthProvider extends NbAbstractAuthProvider {
         ['Something went wrong.']);
     }
 
-    // TODO is it missed messages here, is it token should be defined
-    return new NbAuthResult(true, this.createSuccessResponse(data), '/', ['Successfully logged in.']);
+    return new NbAuthResult(true,
+      this.createSuccessResponse(data),
+      '/',
+      [],
+      ['Successfully logged in.'],
+      this.createToken('test token'));
   }
 }

--- a/src/framework/auth/providers/email-pass-auth.options.ts
+++ b/src/framework/auth/providers/email-pass-auth.options.ts
@@ -24,7 +24,7 @@ export interface NbEmailPassResetModuleConfig extends NbEmailPassModuleConfig {
 }
 
 // TODO postfix to options
-export interface NgEmailPassAuthProviderConfig {
+export interface NbEmailPassAuthProviderConfig {
   baseEndpoint?: string;
   login?: boolean | NbEmailPassModuleConfig;
   register?: boolean | NbEmailPassModuleConfig;

--- a/src/framework/auth/providers/email-pass-auth.provider.ts
+++ b/src/framework/auth/providers/email-pass-auth.provider.ts
@@ -12,7 +12,7 @@ import { switchMap } from 'rxjs/operators/switchMap';
 import { map } from 'rxjs/operators/map';
 import { catchError } from 'rxjs/operators/catchError';
 
-import { NgEmailPassAuthProviderConfig } from './email-pass-auth.options';
+import { NbEmailPassAuthProviderConfig } from './email-pass-auth.options';
 import { NbAuthResult } from '../services/auth-result';
 import { NbAbstractAuthProvider } from './abstract-auth.provider';
 import { getDeepFromObject } from '../helpers';
@@ -112,7 +112,7 @@ import { getDeepFromObject } from '../helpers';
 @Injectable()
 export class NbEmailPassAuthProvider extends NbAbstractAuthProvider {
 
-  protected defaultConfig: NgEmailPassAuthProviderConfig = {
+  protected defaultConfig: NbEmailPassAuthProviderConfig = {
     baseEndpoint: '/api/auth/',
     login: {
       alwaysFail: false,
@@ -188,6 +188,10 @@ export class NbEmailPassAuthProvider extends NbAbstractAuthProvider {
         this.getConfigValue(`${module}.defaultMessages`)),
     },
   };
+
+  static install(name: string, config: NbEmailPassAuthProviderConfig) {
+    return [name, NbEmailPassAuthProvider, config];
+  }
 
   constructor(protected http: HttpClient, private route: ActivatedRoute) {
     super();

--- a/src/framework/auth/providers/email-pass-auth.provider.ts
+++ b/src/framework/auth/providers/email-pass-auth.provider.ts
@@ -189,7 +189,7 @@ export class NbEmailPassAuthProvider extends NbAbstractAuthProvider {
     },
   };
 
-  static install(name: string, config: NbEmailPassAuthProviderConfig) {
+  static register(name: string, config: NbEmailPassAuthProviderConfig) {
     return [name, NbEmailPassAuthProvider, config];
   }
 

--- a/src/framework/auth/providers/email-pass-auth.provider.ts
+++ b/src/framework/auth/providers/email-pass-auth.provider.ts
@@ -13,9 +13,10 @@ import { map } from 'rxjs/operators/map';
 import { catchError } from 'rxjs/operators/catchError';
 
 import { NbEmailPassAuthProviderConfig } from './email-pass-auth.options';
-import { NbAuthResult } from '../services/auth-result';
 import { NbAbstractAuthProvider } from './abstract-auth.provider';
 import { getDeepFromObject } from '../helpers';
+import { NbAuthResult, NbAuthSimpleToken, NbTokenClass } from '../services';
+import { NbProviderRegister } from '../auth.options';
 
 /**
  * The most common authentication provider for email/password strategy.
@@ -189,8 +190,10 @@ export class NbEmailPassAuthProvider extends NbAbstractAuthProvider {
     },
   };
 
-  static register(name: string, config: NbEmailPassAuthProviderConfig) {
-    return [name, NbEmailPassAuthProvider, config];
+  static register(name: string,
+                  config: NbEmailPassAuthProviderConfig,
+                  token: NbTokenClass = NbAuthSimpleToken): NbProviderRegister {
+    return [name, NbEmailPassAuthProvider, config, token];
   }
 
   constructor(protected http: HttpClient, private route: ActivatedRoute) {
@@ -217,7 +220,7 @@ export class NbEmailPassAuthProvider extends NbAbstractAuthProvider {
             this.getConfigValue('login.redirect.success'),
             [],
             this.getConfigValue('messages.getter')('login', res),
-            this.getConfigValue('token.getter')('login', res));
+            this.createToken(this.getConfigValue('token.getter')('login', res)));
         }),
         catchError((res) => {
           let errors = [];
@@ -258,7 +261,7 @@ export class NbEmailPassAuthProvider extends NbAbstractAuthProvider {
             this.getConfigValue('register.redirect.success'),
             [],
             this.getConfigValue('messages.getter')('register', res),
-            this.getConfigValue('token.getter')('register', res));
+            this.createToken(this.getConfigValue('token.getter')('register', res)));
         }),
         catchError((res) => {
           let errors = [];

--- a/src/framework/auth/services/auth-result.ts
+++ b/src/framework/auth/services/auth-result.ts
@@ -3,7 +3,6 @@ import { NbAuthToken } from './token/token';
 export class NbAuthResult {
 
   protected token: NbAuthToken;
-  protected rawToken: string;
   protected errors: string[] = [];
   protected messages: string[] = [];
 
@@ -12,7 +11,7 @@ export class NbAuthResult {
               protected redirect?: any,
               errors?: any,
               messages?: any,
-              rawToken?: string) {
+              token: NbAuthToken = null) {
 
     this.errors = this.errors.concat([errors]);
     if (errors instanceof Array) {
@@ -24,20 +23,15 @@ export class NbAuthResult {
       this.messages = messages;
     }
 
-    this.rawToken = rawToken;
+    this.token = token;
   }
 
   setToken(token: NbAuthToken) {
     this.token = token;
-    this.rawToken = token.toString();
   }
 
   getResponse(): any {
     return this.response;
-  }
-
-  getRawToken(): any {
-    return this.rawToken;
   }
 
   getToken(): any {

--- a/src/framework/auth/services/auth-result.ts
+++ b/src/framework/auth/services/auth-result.ts
@@ -6,6 +6,7 @@ export class NbAuthResult {
   protected errors: string[] = [];
   protected messages: string[] = [];
 
+  // TODO: better pass object
   constructor(protected success: boolean,
               protected response?: any,
               protected redirect?: any,

--- a/src/framework/auth/services/auth.service.ts
+++ b/src/framework/auth/services/auth.service.ts
@@ -154,12 +154,10 @@ export class NbAuthService {
   }
 
   private processResultToken(result: NbAuthResult) {
-    if (result.isSuccess() && result.getRawToken()) {
-      return this.tokenService.setRaw(result.getRawToken())
+    if (result.isSuccess() && result.getToken()) {
+      return this.tokenService.set(result.getToken())
         .pipe(
-          switchMap(() => this.tokenService.get()),
           map((token: NbAuthToken) => {
-            result.setToken(token);
             return result;
           }),
         );

--- a/src/framework/auth/services/auth.service.ts
+++ b/src/framework/auth/services/auth.service.ts
@@ -11,7 +11,7 @@ import { map } from 'rxjs/operators/map';
 import { of as observableOf } from 'rxjs/observable/of';
 
 import { NbAbstractAuthProvider } from '../providers/abstract-auth.provider';
-import { NB_AUTH_PROVIDERS } from '../auth.options';
+import { NbAuthProviders, NB_AUTH_PROVIDERS } from '../auth.options';
 import { NbAuthResult } from './auth-result';
 import { NbTokenService } from './token/token.service';
 import { NbAuthToken } from './token/token';
@@ -25,7 +25,7 @@ export class NbAuthService {
 
   constructor(protected tokenService: NbTokenService,
               protected injector: Injector,
-              @Optional() @Inject(NB_AUTH_PROVIDERS) protected providers = {}) {
+              @Optional() @Inject(NB_AUTH_PROVIDERS) protected providers: NbAuthProviders = {}) {
   }
 
   /**
@@ -173,6 +173,6 @@ export class NbAuthService {
       throw new TypeError(`Nb auth provider '${provider}' is not registered`);
     }
 
-    return this.injector.get(this.providers[provider].service);
+    return this.injector.get(this.providers[provider]);
   }
 }

--- a/src/framework/auth/services/auth.spec.ts
+++ b/src/framework/auth/services/auth.spec.ts
@@ -10,7 +10,7 @@ import { HttpResponse } from '@angular/common/http';
 import { NB_AUTH_OPTIONS, NB_AUTH_TOKEN_CLASS, NB_AUTH_USER_OPTIONS } from '../auth.options';
 import { NbAuthService } from './auth.service';
 import { NbDummyAuthProvider } from '../providers/dummy-auth.provider';
-import { nbAuthServiceFactory, nbOptionsFactory } from '../auth.module';
+import { nbProvidersFactory, nbOptionsFactory } from '../auth.module';
 import { of as observableOf } from 'rxjs/observable/of';
 import { first } from 'rxjs/operators';
 import { NbAuthResult } from './auth-result';
@@ -18,6 +18,7 @@ import { delay } from 'rxjs/operators/delay';
 import { NbTokenService } from './token/token.service';
 import { NbAuthSimpleToken, nbCreateToken } from './token/token';
 import { NbTokenLocalStorage, NbTokenStorage } from './token/token-storage';
+import { NB_AUTH_PROVIDERS } from '../auth.options';
 
 describe('auth-service', () => {
   let authService: NbAuthService;
@@ -75,26 +76,19 @@ describe('auth-service', () => {
                 redirectDelay: 3000,
               },
             },
-            providers: {
-              dummy: {
-                service: NbDummyAuthProvider,
-                config: {
-                  alwaysFail: true,
-                  delay: 1000,
-                },
-              },
-            },
+            providers: [
+              NbDummyAuthProvider.install('dummy', {
+                alwaysFail: true,
+                delay: 1000,
+              }),
+            ],
           },
         },
         { provide: NB_AUTH_OPTIONS, useFactory: nbOptionsFactory, deps: [NB_AUTH_USER_OPTIONS] },
+        { provide: NB_AUTH_PROVIDERS, useFactory: nbProvidersFactory, deps: [NB_AUTH_OPTIONS, Injector] },
         { provide: NbTokenStorage, useClass: NbTokenLocalStorage },
-
         NbTokenService,
-        {
-          provide: NbAuthService,
-          useFactory: nbAuthServiceFactory,
-          deps: [NB_AUTH_OPTIONS, NbTokenService, Injector],
-        },
+        NbAuthService,
         NbDummyAuthProvider,
       ],
     });

--- a/src/framework/auth/services/auth.spec.ts
+++ b/src/framework/auth/services/auth.spec.ts
@@ -77,7 +77,7 @@ describe('auth-service', () => {
               },
             },
             providers: [
-              NbDummyAuthProvider.install('dummy', {
+              NbDummyAuthProvider.register('dummy', {
                 alwaysFail: true,
                 delay: 1000,
               }),

--- a/src/framework/auth/services/token/token-packer.ts
+++ b/src/framework/auth/services/token/token-packer.ts
@@ -1,0 +1,44 @@
+import { Inject, Injectable } from '@angular/core';
+
+import { NB_AUTH_TOKENS } from '../../auth.options';
+import { NbAuthSimpleToken, NbAuthToken, nbCreateToken } from './token';
+
+interface NbTokenPack {
+  class: string,
+  value: string,
+}
+
+/**
+ *
+ */
+@Injectable()
+export class NbAuthTokenPacker {
+
+  constructor(@Inject(NB_AUTH_TOKENS) private availableTokens) {
+  }
+
+  pack(token: NbAuthToken): string {
+    return JSON.stringify({
+      class: token.constructor.name,
+      value: token.toString(),
+    });
+  }
+
+  unpack(rawToken: string): NbAuthToken {
+    let tokenPack: NbTokenPack;
+    try {
+      tokenPack = JSON.parse(rawToken);
+    } catch (e) {
+      console.warn('NbAuthToken: Can not unpack token, using empty `NbAuthSimpleToken`.');
+    }
+
+    let tokenClass = NbAuthSimpleToken;
+    let tokenValue = '';
+    // if we don't have any value stored, we cannot guess a token class, so we set it to default
+    if (tokenPack && tokenPack.class) {
+      tokenClass = this.availableTokens[tokenPack.class] || tokenClass;
+      tokenValue = tokenPack.value;
+    }
+    return nbCreateToken(tokenClass, tokenValue);
+  }
+}

--- a/src/framework/auth/services/token/token-parceler.ts
+++ b/src/framework/auth/services/token/token-parceler.ts
@@ -9,27 +9,27 @@ interface NbTokenPack {
 }
 
 /**
- *
+ * Creates a token parcel which could be stored/restored
  */
 @Injectable()
-export class NbAuthTokenPacker {
+export class NbAuthTokenParceler {
 
   constructor(@Inject(NB_AUTH_TOKENS) private availableTokens) {
   }
 
-  pack(token: NbAuthToken): string {
+  wrap(token: NbAuthToken): string {
     return JSON.stringify({
       class: token.constructor.name,
       value: token.toString(),
     });
   }
 
-  unpack(rawToken: string): NbAuthToken {
+  unwrap(rawToken: string): NbAuthToken {
     let tokenPack: NbTokenPack;
     try {
       tokenPack = JSON.parse(rawToken);
     } catch (e) {
-      console.warn('NbAuthToken: Can not unpack token, using empty `NbAuthSimpleToken`.');
+      console.warn('NbAuthToken: Can not unwrap token, using empty `NbAuthSimpleToken`.');
     }
 
     let tokenClass = NbAuthSimpleToken;

--- a/src/framework/auth/services/token/token-storage.ts
+++ b/src/framework/auth/services/token/token-storage.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { NbAuthToken } from './token';
-import { NbAuthTokenPacker } from './token-packer';
+import { NbAuthTokenParceler } from './token-parceler';
 
 export abstract class NbTokenStorage {
 
@@ -31,7 +31,7 @@ export class NbTokenLocalStorage extends NbTokenStorage {
 
   protected key = 'auth_app_token';
 
-  constructor(private tokenPacker: NbAuthTokenPacker) {
+  constructor(private tokenPacker: NbAuthTokenParceler) {
     super();
   }
 
@@ -40,7 +40,8 @@ export class NbTokenLocalStorage extends NbTokenStorage {
    * @returns {NbAuthToken}
    */
   get(): NbAuthToken {
-    return this.tokenPacker.unpack(localStorage.getItem(this.key));
+    const raw = localStorage.getItem(this.key);
+    return this.tokenPacker.unwrap(raw);
   }
 
   /**
@@ -48,7 +49,8 @@ export class NbTokenLocalStorage extends NbTokenStorage {
    * @param {NbAuthToken} token
    */
   set(token: NbAuthToken) {
-    localStorage.setItem(this.key, this.tokenPacker.pack(token));
+    const raw = this.tokenPacker.wrap(token);
+    localStorage.setItem(this.key, raw);
   }
 
   /**

--- a/src/framework/auth/services/token/token-storage.ts
+++ b/src/framework/auth/services/token/token-storage.ts
@@ -1,7 +1,7 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import { NB_AUTH_TOKEN_CLASS } from '../../auth.options';
-import { NbAuthToken, nbCreateToken, NbTokenClass } from './token';
+import { NbAuthToken } from './token';
+import { NbAuthTokenPacker } from './token-packer';
 
 export abstract class NbTokenStorage {
 
@@ -27,11 +27,12 @@ export abstract class NbTokenStorage {
  *
  */
 @Injectable()
-export class NbTokenLocalStorage implements NbTokenStorage {
+export class NbTokenLocalStorage extends NbTokenStorage {
 
   protected key = 'auth_app_token';
 
-  constructor(@Inject(NB_AUTH_TOKEN_CLASS) protected tokenClass: NbTokenClass) {
+  constructor(private tokenPacker: NbAuthTokenPacker) {
+    super();
   }
 
   /**
@@ -39,7 +40,7 @@ export class NbTokenLocalStorage implements NbTokenStorage {
    * @returns {NbAuthToken}
    */
   get(): NbAuthToken {
-    return nbCreateToken(this.tokenClass, localStorage.getItem(this.key));
+    return this.tokenPacker.unpack(localStorage.getItem(this.key));
   }
 
   /**
@@ -47,7 +48,7 @@ export class NbTokenLocalStorage implements NbTokenStorage {
    * @param {NbAuthToken} token
    */
   set(token: NbAuthToken) {
-    localStorage.setItem(this.key, token.toString());
+    localStorage.setItem(this.key, this.tokenPacker.pack(token));
   }
 
   /**

--- a/src/framework/auth/services/token/token.service.ts
+++ b/src/framework/auth/services/token/token.service.ts
@@ -45,18 +45,6 @@ export class NbTokenService {
   }
 
   /**
-   * Sets a raw token into the storage. This method is used by the NbAuthService automatically.
-   *
-   * @param {string} token
-   * @returns {Observable<any>}
-   */
-  setRaw(token: string): Observable<null> {
-    this.tokenStorage.setRaw(token);
-    this.publishStoredToken();
-    return observableOf(null);
-  }
-
-  /**
    * Returns observable of current token
    * @returns {Observable<NbAuthToken>}
    */


### PR DESCRIPTION
…etter type check

BREAKING CHANGES:
Auth module options' `providers` list changed from key=>value object to array.
So now instead of
```
...
providers: {
  email: {
    service: NbEmailPassAuthProvider,
    config: { ... }
  }
}
```
we do this:

```
providers: [
  NbEmailPassAuthProvider.install('email', { ... }),
]
```
This way we can type-check the configuration object for each provider specified.

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
