### PR TITLE
fix(menu): trigger change detection after setting max-height

### DIFF
--- a/src/framework/theme/components/menu/menu.component.ts
+++ b/src/framework/theme/components/menu/menu.component.ts
@@ -18,6 +18,7 @@ import {
   AfterViewInit,
   PLATFORM_ID,
   Inject,
+  ChangeDetectorRef,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { Router, NavigationEnd } from '@angular/router';
@@ -56,6 +57,7 @@ export class NbMenuItemComponent implements AfterViewInit, OnDestroy {
   constructor(
     private menuService: NbMenuService,
     @Inject(PLATFORM_ID) private platformId: Object,
+    private changeDetection: ChangeDetectorRef,
   ) { }
 
   ngAfterViewInit() {
@@ -70,10 +72,9 @@ export class NbMenuItemComponent implements AfterViewInit, OnDestroy {
       .pipe(takeWhile(() => this.alive))
       .subscribe(() => this.updateMaxHeight());
 
-    setTimeout(() => {
-      this.updateSubmenuHeight();
-      this.updateMaxHeight();
-    });
+    this.updateSubmenuHeight();
+    this.updateMaxHeight();
+    this.changeDetection.detectChanges();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
To animate menu expanding we need to know height of all expoanded children.
Since children cann't be accessed before AfterViewInit hook, we have to calc
and set 'maxHeight' there, but it causing ExpressionChangedAfterItHasBeenCheckedError
error. Since 'maxHeight' can't be calculated earlier, we have to trigger change detection
again. This is a common workaround for this error.

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fix #263 
