### PR TITLE
refactor(auth): rename auth provider to strategy

### DIFF
--- a/docs/articles/auth-install.md
+++ b/docs/articles/auth-install.md
@@ -10,15 +10,15 @@
 1) First, let's install the module as it's distributed as an npm package, but make sure you have the [Nebular Theme module up and running](https://akveo.github.io/nebular/#/docs/installation/add-into-existing-project).
 Nebular Theme is required to use built-in Auth Components. If you are not going to use those at all, you can use `Auth Module` without `Nebular Theme`. 
 
-Let's assume that we need to setup email & password authentication based on Nebular Auth and NbEmailPassAuthProvider.
+Let's assume that we need to setup email & password authentication based on Nebular Auth and `NbDefaultAuthStrategy`.
 
 `npm i @nebular/auth`
     
-2) Import the module and `NbEmailPassAuthProvider` provider:
+2) Import the module and `NbDefaultAuthStrategy` strategy:
 
-`import { NbEmailPassAuthProvider, NbAuthModule } from '@nebular/auth';`
+`import { NbDefaultAuthStrategy, NbAuthModule } from '@nebular/auth';`
 
-3) Now, let's configure the module by specifying available providers, in your case we add `NbEmailPassAuthProvider`:
+3) Now, let's configure the module by specifying available strategies, in your case we add `NbDefaultAuthStrategy`:
 
 ```typescript
 
@@ -27,9 +27,9 @@ Let's assume that we need to setup email & password authentication based on Nebu
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
+         strategies: {
            email: {
-             service: NbEmailPassAuthProvider,
+             service: NbDefaultAuthStrategy,
              config: {
               ...
              },
@@ -114,5 +114,5 @@ At this point, if you navigate to http://localhost:4200/#/auth/login the login f
 
 ## Where to next
 
-- [Configuring a provider](#/docs/auth/configuring-a-provider)
+- [Configuring a Strategy](#/docs/auth/configuring-a-strategy)
 - Adjusting [Auth Components UI](#/docs/auth/configuring-ui)

--- a/docs/articles/auth-intro.md
+++ b/docs/articles/auth-intro.md
@@ -1,5 +1,5 @@
 The main goal of the Auth module is to provide a pluggable set of components and services for easier setup of the authentication layer for the Angular applications.
-The module separates the UI part (login/register components) from the business logic with help of the `authentication providers` layer. 
+The module separates the UI part (login/register components) from the business logic with help of the authentication `Strategies` layer. 
 
 <div class="note note-info">
   <div class="note-title">Note</div>
@@ -20,12 +20,12 @@ Authentication UI components:
 
 You can use the built-in components or create your custom ones.  
   
-Auth providers:
-  - `NbDummyAuthProvider` - simple provider for testing purposes, could be used to simulate backend responses while API is in the development;
-  - `NbEmailPassAuthProvider` - the most common email/password authentication strategy.
+Auth Strategies:
+  - `NbDummyAuthStrategy` - simple strategy for testing purposes, could be used to simulate backend responses while API is in the development;
+  - `NbDefaultAuthStrategy` - the most common email/password authentication strategy.
     
 Other helper services:
-  - `NbAuthService` - facade service to communicate with a configured provider;
+  - `NbAuthService` - facade service to communicate with a configured strategy;
   - `NbTokenService` - service that allows you to manage authentication token - get, set, clear and also listen to token changes over time;
   - `NbTokenLocalStorage` - storage service for storing tokens in a browser local storage;
   - `NbAuthJWTToken` and `NbAuthSimpleToken` - helper classes to work with your token;

--- a/docs/articles/auth-strategy.md
+++ b/docs/articles/auth-strategy.md
@@ -1,19 +1,19 @@
-## A provider
+## A Strategy
 
-In Nebular terms `auth provider` is a class containing authentication logic specific for some authentication flow (email&password, OAuth, etc). 
+In Nebular terms `auth strategy` is a class containing authentication logic specific for some authentication flow (email&password, OAuth2, etc). 
 It accepts user input (login/email/password/token/etc), communicates the input to the backend API and finally provides the resulting output back to the Auth UI layer.
 Currently, there are two Auth Providers available out of the box:
 
-Two auth providers:
-  - `NbDummyAuthProvider` - simple provider for testing purposes, could be used to simulate backend responses while API is in the development;
-  - `NbEmailPassAuthProvider` - the most common email/password authentication strategy.
+Two auth Strategies:
+  - `NbDummyAuthStrategy` - simple strategy for testing purposes, could be used to simulate backend responses while API is in the development;
+  - `NbDefaultAuthStrategy` - the most common email/password authentication strategy.
   
-Each provider has a list of configurations available with the default values set. But you can adjust the settings based on your requirements.
+Each Strategy has a list of configurations available with the default values set. But you can adjust the settings based on your requirements.
 <hr class="section-end">
   
 ## Configuration
 
-As an example, let's configure API endpoints for the `NbEmailPassAuthProvider`. The provider is configured by default, please take a look at the [default configuration values](#/docs/auth/nbemailpassauthprovider) if you need any custom behaviour.
+As an example, let's configure API endpoints for the `NbDefaultAuthStrategy`. The strategy is configured by default, please take a look at the [default configuration values](#/docs/auth/nbdefaultauthstrategy) if you need any custom behaviour.
 We assume you already have the Auth module installed inside of your `*.module.ts`:
 
 
@@ -24,9 +24,9 @@ We assume you already have the Auth module installed inside of your `*.module.ts
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
+         strategies: {
            email: {
-             service: NbEmailPassAuthProvider,
+             service: NbDefaultAuthStrategy,
              config: {
               ...
              },
@@ -38,7 +38,7 @@ We assume you already have the Auth module installed inside of your `*.module.ts
 
 ```
 
-Now, let's add API endpoints. According to the [NbEmailPassAuthProvider documentation](#/docs/auth/nbemailpassauthprovider), we have `baseEndpoint` setting, and also an `endpoint` setting for each function (login/register/etc):
+Now, let's add API endpoints. According to the [NbDefaultAuthStrategy documentation](#/docs/auth/nbdefaultauthstrategy), we have `baseEndpoint` setting, and also an `endpoint` setting for each function (login/register/etc):
 
 ```typescript
 {
@@ -89,7 +89,7 @@ And configure the endpoints, considering that the final endpoint will consist of
 }
 ```
 
-Finally, let's presume that unlike in the default provider settings, our API accepts only `HTTP POST`, so let's fix that too: 
+Finally, let's presume that unlike in the default strategy settings, our API accepts only `HTTP POST`, so let's fix that too: 
 
 ```typescript
 {
@@ -120,7 +120,7 @@ Finally, let's presume that unlike in the default provider settings, our API acc
 <div class="note note-info">
   <div class="note-title">Note</div>
   <div class="note-body">
-    No need to list all available configurations there. Your settings will be merged with default provider settings accordingly.
+    No need to list all available configurations there. Your settings will be merged with default strategy settings accordingly.
   </div>
 </div>
 

--- a/docs/articles/auth-token.md
+++ b/docs/articles/auth-token.md
@@ -1,7 +1,7 @@
 ## Receiving user token after login/registration
 
 At this step, we assume that Nebular Auth module is up and running, 
-you have successfully configured an auth provider and adjusted auth look & fell accordingly with your requirements.
+you have successfully configured an auth strategy and adjusted auth look & fell accordingly with your requirements.
 
 It's time to get a user token after successful authentication to be able to communicate with the server and, for instance, show a username in the header of the application.
 Let's assume that your backend returns a JWT token so that we can use the token payload to extract a user info out of it.
@@ -42,9 +42,9 @@ We'll assume that our API returns a token as just `{token: 'some-jwt-token'}` no
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
+         strategies: {
            email: {
-             service: NbEmailPassAuthProvider,
+             service: NbDefaultAuthStrategy,
              config: {
                ...
                 

--- a/docs/articles/auth-ui.md
+++ b/docs/articles/auth-ui.md
@@ -12,7 +12,7 @@ Auth module comes with a list of authentication components:
 
 ## UI Settings
 
-Alongside with the provider's configuration `AuthModule` also accepts a list of settings for UI side under the `forms` key:
+Alongside with the strategies' configuration `AuthModule` also accepts a list of settings for UI side under the `forms` key:
 
 ```typescript
 
@@ -21,9 +21,9 @@ Alongside with the provider's configuration `AuthModule` also accepts a list of 
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
+         strategies: {
            email: {
-             service: NbEmailPassAuthProvider,
+             service: NbDefaultAuthStrategy,
              config: {
               ...
              },
@@ -54,7 +54,7 @@ export const defaultSettings: any = {
   forms: {
     login: {
       redirectDelay: 500, // delay before redirect after a successful login, while success message is shown to the user
-      provider: 'email',  // provider id key. If you have multiple providers, or what to use your own
+      strategy: 'email',  // strategy id key.
       rememberMe: true,   // whether to show or not the `rememberMe` checkbox
       showMessages: {     // show/not show success/error messages
         success: true,
@@ -64,7 +64,7 @@ export const defaultSettings: any = {
     },
     register: {
       redirectDelay: 500,
-      provider: 'email',
+      strategy: 'email',
       showMessages: {
         success: true,
         error: true,
@@ -74,7 +74,7 @@ export const defaultSettings: any = {
     },
     requestPassword: {
       redirectDelay: 500,
-      provider: 'email',
+      strategy: 'email',
       showMessages: {
         success: true,
         error: true,
@@ -83,7 +83,7 @@ export const defaultSettings: any = {
     },
     resetPassword: {
       redirectDelay: 500,
-      provider: 'email',
+      strategy: 'email',
       showMessages: {
         success: true,
         error: true,
@@ -92,7 +92,7 @@ export const defaultSettings: any = {
     },
     logout: {
       redirectDelay: 500,
-      provider: 'email',
+      strategy: 'email',
     },
     validation: {
       password: {
@@ -122,9 +122,9 @@ So, for instance, to remove the redirectDelay setting and disable the success me
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
+         strategies: {
            email: {
-             service: NbEmailPassAuthProvider,
+             service: NbDefaultAuthStrategy,
              config: {
               ...
              },
@@ -181,9 +181,9 @@ const formSetting: any = {
    // ...
     
    NbAuthModule.forRoot({
-         providers: {
+         strategies: {
            email: {
-             service: NbEmailPassAuthProvider,
+             service: NbDefaultAuthStrategy,
              config: {
               ...
              },
@@ -312,7 +312,7 @@ export const routes: Routes = [
 ];
 ```
 
-That's it. Now you can adjust the components the way you need. Though please make sure to keep the NbAuthService related logic untouched, so that the components may still communicate with the auth providers.
+That's it. Now you can adjust the components the way you need. Though please make sure to keep the NbAuthService related logic untouched, so that the components may still communicate with the auth strategies.
 <hr class="section-end">
 
 ## Where to next

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -23,7 +23,7 @@ Nebular modules are distributed as separated `npm` packages, here's a list of cu
   - Server-side rendering compatibility!
 - **@nebular/auth**
   - Authentication components (login/register/reset password/restore password).
-  - Multiple configurable providers (backend connectors).
+  - Multiple configurable authentication Strategies (backend connectors).
   - Helpers for token management (storing, passing with HTTP requests, etc).
 - **@nebular/security** - module for roles and permissions management.
 

--- a/docs/structure.ts
+++ b/docs/structure.ts
@@ -478,12 +478,12 @@ export const STRUCTURE = [
       },
       {
         type: 'page',
-        name: 'Configuring a provider',
+        name: 'Configuring a Strategy',
         children: [
           {
             type: 'block',
             block: 'markdown',
-            source: 'auth-provider.md',
+            source: 'auth-strategy.md',
           },
         ],
       },
@@ -533,12 +533,12 @@ export const STRUCTURE = [
       },
       {
         type: 'page',
-        name: 'NbEmailPassAuthProvider',
+        name: 'NbDefaultAuthStrategy',
         children: [
           {
             type: 'block',
             block: 'component',
-            source: 'NbEmailPassAuthProvider',
+            source: 'NbDefaultAuthStrategy',
           },
         ],
       },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,7 +30,7 @@ import {
   NB_AUTH_TOKEN_CLASS,
   NbAuthJWTToken,
   NbAuthModule,
-  NbEmailPassAuthProvider,
+  NbDefaultAuthStrategy,
   NbAuthJWTInterceptor,
 } from '@nebular/auth';
 
@@ -166,17 +166,17 @@ const NB_TEST_COMPONENTS = [
           ],
         },
       },
-      providers: {
+      strategies: {
         //
         // email: {
-        //   service: NbDummyAuthProvider,
+        //   service: NbDummyAuthStrategy,
         //   config: {
         //     alwaysFail: true,
         //     delay: 1000,
         //   },
         // },
         email: {
-          service: NbEmailPassAuthProvider,
+          service: NbDefaultAuthStrategy,
           config: {
             login: {
               endpoint: 'http://localhost:4400/api/auth/login',

--- a/src/framework/auth/auth.module.ts
+++ b/src/framework/auth/auth.module.ts
@@ -6,17 +6,14 @@ import { HttpClientModule } from '@angular/common/http';
 
 import { NbLayoutModule, NbCardModule, NbCheckboxModule } from '@nebular/theme';
 
-import { NbAuthService } from './services/auth.service';
-import { NbDummyAuthProvider } from './providers/dummy-auth.provider';
-import { NbEmailPassAuthProvider } from './providers/email-pass-auth.provider';
-import { NbTokenService } from './services/token/token.service';
-import { NbAuthSimpleToken } from './services/token/token';
-import { NbTokenLocalStorage, NbTokenStorage } from './services/token/token-storage';
+import { NbAuthService, NbTokenService, NbAuthSimpleToken, NbTokenLocalStorage, NbTokenStorage } from './services';
+import { NbDummyAuthStrategy, NbDefaultAuthStrategy } from './strategies';
+
 import {
-  defaultSettings,
+  defaultOptions,
   NB_AUTH_USER_OPTIONS,
   NB_AUTH_OPTIONS,
-  NB_AUTH_PROVIDERS,
+  NB_AUTH_STRATEGIES,
   NbAuthOptions, NB_AUTH_INTERCEPTOR_HEADER, NB_AUTH_TOKEN_CLASS,
 } from './auth.options';
 
@@ -32,22 +29,22 @@ import { NbResetPasswordComponent } from './components/reset-password/reset-pass
 import { routes } from './auth.routes';
 import { deepExtend } from './helpers';
 
-export function nbAuthServiceFactory(config: any, tokenService: NbTokenService, injector: Injector) {
-  const providers = config.providers || {};
+export function nbAuthServiceFactory(options: any, tokenService: NbTokenService, injector: Injector) {
+  const strategies = options.strategies || {};
 
-  for (const key in providers) {
-    if (providers.hasOwnProperty(key)) {
-      const provider = providers[key];
-      const object = injector.get(provider.service);
-      object.setConfig(provider.config || {});
+  for (const key in strategies) {
+    if (strategies.hasOwnProperty(key)) {
+      const strategy = strategies[key];
+      const object = injector.get(strategy.service);
+      object.setConfig(strategy.config || {});
     }
   }
 
-  return new NbAuthService(tokenService, injector, providers);
+  return new NbAuthService(tokenService, injector, strategies);
 }
 
 export function nbOptionsFactory(options) {
-  return deepExtend(defaultSettings, options);
+  return deepExtend(defaultOptions, options);
 }
 
 @NgModule({
@@ -86,7 +83,7 @@ export class NbAuthModule {
       providers: [
         { provide: NB_AUTH_USER_OPTIONS, useValue: nbAuthOptions },
         { provide: NB_AUTH_OPTIONS, useFactory: nbOptionsFactory, deps: [NB_AUTH_USER_OPTIONS] },
-        { provide: NB_AUTH_PROVIDERS, useValue: {} },
+        { provide: NB_AUTH_STRATEGIES, useValue: {} },
         { provide: NB_AUTH_TOKEN_CLASS, useValue: NbAuthSimpleToken },
         { provide: NB_AUTH_INTERCEPTOR_HEADER, useValue: 'Authorization' },
         {
@@ -96,8 +93,8 @@ export class NbAuthModule {
         },
         { provide: NbTokenStorage, useClass: NbTokenLocalStorage },
         NbTokenService,
-        NbDummyAuthProvider,
-        NbEmailPassAuthProvider,
+        NbDummyAuthStrategy,
+        NbDefaultAuthStrategy,
       ],
     };
   }

--- a/src/framework/auth/auth.options.ts
+++ b/src/framework/auth/auth.options.ts
@@ -3,10 +3,10 @@ import { NbAuthToken } from './services';
 
 export interface NbAuthOptions {
   forms?: any;
-  providers?: any;
+  strategies?: any;
 }
 
-export interface NbAuthProviders {
+export interface NbAuthStrategies {
   [key: string]: any;
 }
 
@@ -20,11 +20,11 @@ export interface NbAuthSocialLink {
 
 const socialLinks: NbAuthSocialLink[] = [];
 
-export const defaultSettings: any = {
+export const defaultOptions: any = {
   forms: {
     login: {
       redirectDelay: 500, // delay before redirect after a successful login, while success message is shown to the user
-      provider: 'email',  // provider id key. If you have multiple providers, or what to use your own
+      strategy: 'email',  // provider id key. If you have multiple strategies, or what to use your own
       rememberMe: true,   // whether to show or not the `rememberMe` checkbox
       showMessages: {     // show/not show success/error messages
         success: true,
@@ -34,7 +34,7 @@ export const defaultSettings: any = {
     },
     register: {
       redirectDelay: 500,
-      provider: 'email',
+      strategy: 'email',
       showMessages: {
         success: true,
         error: true,
@@ -44,7 +44,7 @@ export const defaultSettings: any = {
     },
     requestPassword: {
       redirectDelay: 500,
-      provider: 'email',
+      strategy: 'email',
       showMessages: {
         success: true,
         error: true,
@@ -53,7 +53,7 @@ export const defaultSettings: any = {
     },
     resetPassword: {
       redirectDelay: 500,
-      provider: 'email',
+      strategy: 'email',
       showMessages: {
         success: true,
         error: true,
@@ -62,7 +62,7 @@ export const defaultSettings: any = {
     },
     logout: {
       redirectDelay: 500,
-      provider: 'email',
+      strategy: 'email',
     },
     validation: {
       password: {
@@ -84,6 +84,6 @@ export const defaultSettings: any = {
 
 export const NB_AUTH_OPTIONS = new InjectionToken<NbAuthOptions>('Nebular Auth Options');
 export const NB_AUTH_USER_OPTIONS = new InjectionToken<NbAuthOptions>('Nebular User Auth Options');
-export const NB_AUTH_PROVIDERS = new InjectionToken<NbAuthProviders>('Nebular Auth Providers');
+export const NB_AUTH_STRATEGIES = new InjectionToken<NbAuthStrategies>('Nebular Auth Strategies');
 export const NB_AUTH_TOKEN_CLASS = new InjectionToken<NbAuthToken>('Nebular Token Class');
-export const NB_AUTH_INTERCEPTOR_HEADER = new InjectionToken<NbAuthProviders>('Nebular Simple Interceptor Header');
+export const NB_AUTH_INTERCEPTOR_HEADER = new InjectionToken<NbAuthStrategies>('Nebular Simple Interceptor Header');

--- a/src/framework/auth/components/login/login.component.ts
+++ b/src/framework/auth/components/login/login.component.ts
@@ -111,7 +111,7 @@ export class NbLoginComponent {
 
   redirectDelay: number = 0;
   showMessages: any = {};
-  provider: string = '';
+  strategy: string = '';
 
   errors: string[] = [];
   messages: string[] = [];
@@ -125,7 +125,7 @@ export class NbLoginComponent {
 
     this.redirectDelay = this.getConfigValue('forms.login.redirectDelay');
     this.showMessages = this.getConfigValue('forms.login.showMessages');
-    this.provider = this.getConfigValue('forms.login.provider');
+    this.strategy = this.getConfigValue('forms.login.strategy');
     this.socialLinks = this.getConfigValue('forms.login.socialLinks');
   }
 
@@ -133,7 +133,7 @@ export class NbLoginComponent {
     this.errors = this.messages = [];
     this.submitted = true;
 
-    this.service.authenticate(this.provider, this.user).subscribe((result: NbAuthResult) => {
+    this.service.authenticate(this.strategy, this.user).subscribe((result: NbAuthResult) => {
       this.submitted = false;
 
       if (result.isSuccess()) {

--- a/src/framework/auth/components/logout/logout.component.ts
+++ b/src/framework/auth/components/logout/logout.component.ts
@@ -20,21 +20,21 @@ import { NbAuthResult } from '../../services/auth-result';
 export class NbLogoutComponent implements OnInit {
 
   redirectDelay: number = 0;
-  provider: string = '';
+  strategy: string = '';
 
   constructor(protected service: NbAuthService,
               @Inject(NB_AUTH_OPTIONS) protected config = {},
               protected router: Router) {
     this.redirectDelay = this.getConfigValue('forms.logout.redirectDelay');
-    this.provider = this.getConfigValue('forms.logout.provider');
+    this.strategy = this.getConfigValue('forms.logout.strategy');
   }
 
   ngOnInit(): void {
-    this.logout(this.provider);
+    this.logout(this.strategy);
   }
 
-  logout(provider: string): void {
-    this.service.logout(provider).subscribe((result: NbAuthResult) => {
+  logout(strategy: string): void {
+    this.service.logout(strategy).subscribe((result: NbAuthResult) => {
 
       const redirect = result.getRedirect();
       if (redirect) {

--- a/src/framework/auth/components/register/register.component.ts
+++ b/src/framework/auth/components/register/register.component.ts
@@ -151,7 +151,7 @@ export class NbRegisterComponent {
 
   redirectDelay: number = 0;
   showMessages: any = {};
-  provider: string = '';
+  strategy: string = '';
 
   submitted = false;
   errors: string[] = [];
@@ -165,7 +165,7 @@ export class NbRegisterComponent {
 
     this.redirectDelay = this.getConfigValue('forms.register.redirectDelay');
     this.showMessages = this.getConfigValue('forms.register.showMessages');
-    this.provider = this.getConfigValue('forms.register.provider');
+    this.strategy = this.getConfigValue('forms.register.strategy');
     this.socialLinks = this.getConfigValue('forms.login.socialLinks');
   }
 
@@ -173,7 +173,7 @@ export class NbRegisterComponent {
     this.errors = this.messages = [];
     this.submitted = true;
 
-    this.service.register(this.provider, this.user).subscribe((result: NbAuthResult) => {
+    this.service.register(this.strategy, this.user).subscribe((result: NbAuthResult) => {
       this.submitted = false;
       if (result.isSuccess()) {
         this.messages = result.getMessages();

--- a/src/framework/auth/components/request-password/request-password.component.ts
+++ b/src/framework/auth/components/request-password/request-password.component.ts
@@ -68,7 +68,7 @@ export class NbRequestPasswordComponent {
 
   redirectDelay: number = 0;
   showMessages: any = {};
-  provider: string = '';
+  strategy: string = '';
 
   submitted = false;
   errors: string[] = [];
@@ -81,14 +81,14 @@ export class NbRequestPasswordComponent {
 
     this.redirectDelay = this.getConfigValue('forms.requestPassword.redirectDelay');
     this.showMessages = this.getConfigValue('forms.requestPassword.showMessages');
-    this.provider = this.getConfigValue('forms.requestPassword.provider');
+    this.strategy = this.getConfigValue('forms.requestPassword.strategy');
   }
 
   requestPass(): void {
     this.errors = this.messages = [];
     this.submitted = true;
 
-    this.service.requestPassword(this.provider, this.user).subscribe((result: NbAuthResult) => {
+    this.service.requestPassword(this.strategy, this.user).subscribe((result: NbAuthResult) => {
       this.submitted = false;
       if (result.isSuccess()) {
         this.messages = result.getMessages();

--- a/src/framework/auth/components/reset-password/reset-password.component.ts
+++ b/src/framework/auth/components/reset-password/reset-password.component.ts
@@ -90,7 +90,7 @@ export class NbResetPasswordComponent {
 
   redirectDelay: number = 0;
   showMessages: any = {};
-  provider: string = '';
+  strategy: string = '';
 
   submitted = false;
   errors: string[] = [];
@@ -103,14 +103,14 @@ export class NbResetPasswordComponent {
 
     this.redirectDelay = this.getConfigValue('forms.resetPassword.redirectDelay');
     this.showMessages = this.getConfigValue('forms.resetPassword.showMessages');
-    this.provider = this.getConfigValue('forms.resetPassword.provider');
+    this.strategy = this.getConfigValue('forms.resetPassword.strategy');
   }
 
   resetPass(): void {
     this.errors = this.messages = [];
     this.submitted = true;
 
-    this.service.resetPassword(this.provider, this.user).subscribe((result: NbAuthResult) => {
+    this.service.resetPassword(this.strategy, this.user).subscribe((result: NbAuthResult) => {
       this.submitted = false;
       if (result.isSuccess()) {
         this.messages = result.getMessages();

--- a/src/framework/auth/providers/index.ts
+++ b/src/framework/auth/providers/index.ts
@@ -1,3 +1,0 @@
-export * from './abstract-auth.provider';
-export * from './dummy-auth.provider';
-export * from './email-pass-auth.provider';

--- a/src/framework/auth/services/auth.service.ts
+++ b/src/framework/auth/services/auth.service.ts
@@ -10,22 +10,22 @@ import { switchMap } from 'rxjs/operators/switchMap';
 import { map } from 'rxjs/operators/map';
 import { of as observableOf } from 'rxjs/observable/of';
 
-import { NbAbstractAuthProvider } from '../providers/abstract-auth.provider';
-import { NB_AUTH_PROVIDERS } from '../auth.options';
+import { NbAuthStrategy } from '../strategies/auth-strategy';
+import { NB_AUTH_STRATEGIES } from '../auth.options';
 import { NbAuthResult } from './auth-result';
 import { NbTokenService } from './token/token.service';
 import { NbAuthToken } from './token/token';
 
 /**
  * Common authentication service.
- * Should be used to as an interlayer between UI Components and Auth Providers.
+ * Should be used to as an interlayer between UI Components and Auth Strategy.
  */
 @Injectable()
 export class NbAuthService {
 
   constructor(protected tokenService: NbTokenService,
               protected injector: Injector,
-              @Optional() @Inject(NB_AUTH_PROVIDERS) protected providers = {}) {
+              @Optional() @Inject(NB_AUTH_STRATEGIES) protected strategies = {}) {
   }
 
   /**
@@ -63,18 +63,18 @@ export class NbAuthService {
   }
 
   /**
-   * Authenticates with the selected provider
+   * Authenticates with the selected strategy
    * Stores received token in the token storage
    *
    * Example:
    * authenticate('email', {email: 'email@example.com', password: 'test'})
    *
-   * @param provider
+   * @param strategyName
    * @param data
    * @returns {Observable<NbAuthResult>}
    */
-  authenticate(provider: string, data?: any): Observable<NbAuthResult> {
-    return this.getProvider(provider).authenticate(data)
+  authenticate(strategyName: string, data?: any): Observable<NbAuthResult> {
+    return this.getStrategy(strategyName).authenticate(data)
       .pipe(
         switchMap((result: NbAuthResult) => {
           return this.processResultToken(result);
@@ -83,18 +83,18 @@ export class NbAuthService {
   }
 
   /**
-   * Registers with the selected provider
+   * Registers with the selected strategy
    * Stores received token in the token storage
    *
    * Example:
    * register('email', {email: 'email@example.com', name: 'Some Name', password: 'test'})
    *
-   * @param provider
+   * @param strategyName
    * @param data
    * @returns {Observable<NbAuthResult>}
    */
-  register(provider: string, data?: any): Observable<NbAuthResult> {
-    return this.getProvider(provider).register(data)
+  register(strategyName: string, data?: any): Observable<NbAuthResult> {
+    return this.getStrategy(strategyName).register(data)
       .pipe(
         switchMap((result: NbAuthResult) => {
           return this.processResultToken(result);
@@ -103,17 +103,17 @@ export class NbAuthService {
   }
 
   /**
-   * Sign outs with the selected provider
+   * Sign outs with the selected strategy
    * Removes token from the token storage
    *
    * Example:
    * logout('email')
    *
-   * @param provider
+   * @param strategyName
    * @returns {Observable<NbAuthResult>}
    */
-  logout(provider: string): Observable<NbAuthResult> {
-    return this.getProvider(provider).logout()
+  logout(strategyName: string): Observable<NbAuthResult> {
+    return this.getStrategy(strategyName).logout()
       .pipe(
         switchMap((result: NbAuthResult) => {
           if (result.isSuccess()) {
@@ -126,31 +126,31 @@ export class NbAuthService {
   }
 
   /**
-   * Sends forgot password request to the selected provider
+   * Sends forgot password request to the selected strategy
    *
    * Example:
    * requestPassword('email', {email: 'email@example.com'})
    *
-   * @param provider
+   * @param strategyName
    * @param data
    * @returns {Observable<NbAuthResult>}
    */
-  requestPassword(provider: string, data?: any): Observable<NbAuthResult> {
-    return this.getProvider(provider).requestPassword(data);
+  requestPassword(strategyName: string, data?: any): Observable<NbAuthResult> {
+    return this.getStrategy(strategyName).requestPassword(data);
   }
 
   /**
-   * Tries to reset password with the selected provider
+   * Tries to reset password with the selected strategy
    *
    * Example:
    * resetPassword('email', {newPassword: 'test'})
    *
-   * @param provider
+   * @param strategyName
    * @param data
    * @returns {Observable<NbAuthResult>}
    */
-  resetPassword(provider: string, data?: any): Observable<NbAuthResult> {
-    return this.getProvider(provider).resetPassword(data);
+  resetPassword(strategyName: string, data?: any): Observable<NbAuthResult> {
+    return this.getStrategy(strategyName).resetPassword(data);
   }
 
   private processResultToken(result: NbAuthResult) {
@@ -168,11 +168,11 @@ export class NbAuthService {
     return observableOf(result);
   }
 
-  private getProvider(provider: string): NbAbstractAuthProvider {
-    if (!this.providers[provider]) {
-      throw new TypeError(`Nb auth provider '${provider}' is not registered`);
+  private getStrategy(strategyName: string): NbAuthStrategy {
+    if (!this.strategies[strategyName]) {
+      throw new TypeError(`NbAuthStrategy '${strategyName}' is not registered`);
     }
 
-    return this.injector.get(this.providers[provider].service);
+    return this.injector.get(this.strategies[strategyName].service);
   }
 }

--- a/src/framework/auth/services/auth.spec.ts
+++ b/src/framework/auth/services/auth.spec.ts
@@ -9,7 +9,7 @@ import { Injector } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
 import { NB_AUTH_OPTIONS, NB_AUTH_TOKEN_CLASS, NB_AUTH_USER_OPTIONS } from '../auth.options';
 import { NbAuthService } from './auth.service';
-import { NbDummyAuthProvider } from '../providers/dummy-auth.provider';
+import { NbDummyAuthStrategy } from '../strategies';
 import { nbAuthServiceFactory, nbOptionsFactory } from '../auth.module';
 import { of as observableOf } from 'rxjs/observable/of';
 import { first } from 'rxjs/operators';
@@ -22,7 +22,7 @@ import { NbTokenLocalStorage, NbTokenStorage } from './token/token-storage';
 describe('auth-service', () => {
   let authService: NbAuthService;
   let tokenService: NbTokenService;
-  let dummyAuthProvider: NbDummyAuthProvider;
+  let dummyAuthStrategy: NbDummyAuthStrategy;
   const testTokenValue = 'test-token';
   const replacedTokenValue = 'replaced-value';
 
@@ -75,9 +75,9 @@ describe('auth-service', () => {
                 redirectDelay: 3000,
               },
             },
-            providers: {
+            strategies: {
               dummy: {
-                service: NbDummyAuthProvider,
+                service: NbDummyAuthStrategy,
                 config: {
                   alwaysFail: true,
                   delay: 1000,
@@ -95,12 +95,12 @@ describe('auth-service', () => {
           useFactory: nbAuthServiceFactory,
           deps: [NB_AUTH_OPTIONS, NbTokenService, Injector],
         },
-        NbDummyAuthProvider,
+        NbDummyAuthStrategy,
       ],
     });
     authService = TestBed.get(NbAuthService);
     tokenService = TestBed.get(NbTokenService);
-    dummyAuthProvider = TestBed.get(NbDummyAuthProvider);
+    dummyAuthStrategy = TestBed.get(NbDummyAuthStrategy);
   });
 
   it('get test token before set', () => {
@@ -155,7 +155,7 @@ describe('auth-service', () => {
   );
 
   it('authenticate failed', (done) => {
-      const spy = spyOn(dummyAuthProvider, 'authenticate')
+      const spy = spyOn(dummyAuthStrategy, 'authenticate')
         .and
         .returnValue(observableOf(failResult)
           .pipe(
@@ -177,7 +177,7 @@ describe('auth-service', () => {
   );
 
   it('authenticate succeed', (done) => {
-      const providerSpy = spyOn(dummyAuthProvider, 'authenticate')
+      const strategySpy = spyOn(dummyAuthStrategy, 'authenticate')
         .and
         .returnValue(observableOf(successResult)
           .pipe(
@@ -193,7 +193,7 @@ describe('auth-service', () => {
         .returnValue(observableOf(replacedToken));
 
       authService.authenticate('dummy').subscribe((authRes: NbAuthResult) => {
-        expect(providerSpy).toHaveBeenCalled();
+        expect(strategySpy).toHaveBeenCalled();
         expect(tokenServiceSetSpy).toHaveBeenCalled();
         expect(tokenServiceGetSpy).toHaveBeenCalled();
 
@@ -212,7 +212,7 @@ describe('auth-service', () => {
   );
 
   it('register failed', (done) => {
-      const spy = spyOn(dummyAuthProvider, 'register')
+      const spy = spyOn(dummyAuthStrategy, 'register')
         .and
         .returnValue(observableOf(failResult)
           .pipe(
@@ -235,7 +235,7 @@ describe('auth-service', () => {
   );
 
   it('register succeed', (done) => {
-      const providerSpy = spyOn(dummyAuthProvider, 'register')
+      const strategySpy = spyOn(dummyAuthStrategy, 'register')
         .and
         .returnValue(observableOf(successResult)
           .pipe(
@@ -251,7 +251,7 @@ describe('auth-service', () => {
         .returnValue(observableOf(replacedToken));
 
       authService.register('dummy').subscribe((authRes: NbAuthResult) => {
-        expect(providerSpy).toHaveBeenCalled();
+        expect(strategySpy).toHaveBeenCalled();
         expect(tokenServiceSetSpy).toHaveBeenCalled();
         expect(tokenServiceGetSpy).toHaveBeenCalled();
 
@@ -269,7 +269,7 @@ describe('auth-service', () => {
   );
 
   it('logout failed', (done) => {
-      const spy = spyOn(dummyAuthProvider, 'logout')
+      const spy = spyOn(dummyAuthStrategy, 'logout')
         .and
         .returnValue(observableOf(failResult)
           .pipe(
@@ -292,7 +292,7 @@ describe('auth-service', () => {
   );
 
   it('logout succeed', (done) => {
-      const providerLogoutSpy = spyOn(dummyAuthProvider, 'logout')
+      const strategyLogoutSpy = spyOn(dummyAuthStrategy, 'logout')
         .and
         .returnValue(observableOf(successLogoutResult)
           .pipe(
@@ -301,7 +301,7 @@ describe('auth-service', () => {
       const tokenServiceClearSpy = spyOn(tokenService, 'clear').and.returnValue(observableOf('STUB'));
 
       authService.logout('dummy').subscribe((authRes: NbAuthResult) => {
-        expect(providerLogoutSpy).toHaveBeenCalled();
+        expect(strategyLogoutSpy).toHaveBeenCalled();
         expect(tokenServiceClearSpy).toHaveBeenCalled();
 
         expect(authRes.isFailure()).toBeFalsy();
@@ -317,7 +317,7 @@ describe('auth-service', () => {
   );
 
   it('requestPassword failed', (done) => {
-      const spy = spyOn(dummyAuthProvider, 'requestPassword')
+      const spy = spyOn(dummyAuthStrategy, 'requestPassword')
         .and
         .returnValue(observableOf(failResult)
           .pipe(
@@ -340,7 +340,7 @@ describe('auth-service', () => {
   );
 
   it('requestPassword succeed', (done) => {
-      const providerLogoutSpy = spyOn(dummyAuthProvider, 'requestPassword')
+      const strategyLogoutSpy = spyOn(dummyAuthStrategy, 'requestPassword')
         .and
         .returnValue(observableOf(successRequestPasswordResult)
           .pipe(
@@ -348,7 +348,7 @@ describe('auth-service', () => {
           ));
 
       authService.requestPassword('dummy').subscribe((authRes: NbAuthResult) => {
-        expect(providerLogoutSpy).toHaveBeenCalled();
+        expect(strategyLogoutSpy).toHaveBeenCalled();
 
         expect(authRes.isFailure()).toBeFalsy();
         expect(authRes.isSuccess()).toBeTruthy();
@@ -363,7 +363,7 @@ describe('auth-service', () => {
   );
 
   it('resetPassword failed', (done) => {
-      const spy = spyOn(dummyAuthProvider, 'resetPassword')
+      const spy = spyOn(dummyAuthStrategy, 'resetPassword')
         .and
         .returnValue(observableOf(failResult)
           .pipe(
@@ -386,7 +386,7 @@ describe('auth-service', () => {
   );
 
   it('resetPassword succeed', (done) => {
-      const providerLogoutSpy = spyOn(dummyAuthProvider, 'resetPassword')
+      const strategyLogoutSpy = spyOn(dummyAuthStrategy, 'resetPassword')
         .and
         .returnValue(observableOf(successResetPasswordResult)
           .pipe(
@@ -394,7 +394,7 @@ describe('auth-service', () => {
           ));
 
       authService.resetPassword('dummy').subscribe((authRes: NbAuthResult) => {
-        expect(providerLogoutSpy).toHaveBeenCalled();
+        expect(strategyLogoutSpy).toHaveBeenCalled();
 
         expect(authRes.isFailure()).toBeFalsy();
         expect(authRes.isSuccess()).toBeTruthy();

--- a/src/framework/auth/strategies/auth-strategy.ts
+++ b/src/framework/auth/strategies/auth-strategy.ts
@@ -4,7 +4,7 @@ import { NbAuthResult } from '../services/auth-result';
 
 import { deepExtend, getDeepFromObject } from '../helpers';
 
-export abstract class NbAbstractAuthProvider {
+export abstract class NbAuthStrategy {
 
   protected defaultConfig: any = {};
   protected config: any = {};

--- a/src/framework/auth/strategies/default/default-strategy-options.ts
+++ b/src/framework/auth/strategies/default/default-strategy-options.ts
@@ -5,7 +5,7 @@
  */
 
 // TODO postfix to options
-export interface NbEmailPassModuleConfig {
+export interface NbDefaultStrategyModule {
   alwaysFail?: boolean;
   rememberMe?: boolean;
   endpoint?: string;
@@ -19,18 +19,18 @@ export interface NbEmailPassModuleConfig {
 }
 
 // TODO postfix to options
-export interface NbEmailPassResetModuleConfig extends NbEmailPassModuleConfig {
+export interface NbDefaultStrategyReset extends NbDefaultStrategyModule {
   resetPasswordTokenKey?: string;
 }
 
 // TODO postfix to options
-export interface NgEmailPassAuthProviderConfig {
+export interface NbDefaultAuthStrategyOptions {
   baseEndpoint?: string;
-  login?: boolean | NbEmailPassModuleConfig;
-  register?: boolean | NbEmailPassModuleConfig;
-  requestPass?: boolean | NbEmailPassModuleConfig;
-  resetPass?: boolean | NbEmailPassResetModuleConfig;
-  logout?: boolean | NbEmailPassResetModuleConfig;
+  login?: boolean | NbDefaultStrategyModule;
+  register?: boolean | NbDefaultStrategyModule;
+  requestPass?: boolean | NbDefaultStrategyModule;
+  resetPass?: boolean | NbDefaultStrategyReset;
+  logout?: boolean | NbDefaultStrategyReset;
   token?: {
     key?: string;
     getter?: Function;

--- a/src/framework/auth/strategies/default/default-strategy.spec.ts
+++ b/src/framework/auth/strategies/default/default-strategy.spec.ts
@@ -5,16 +5,16 @@
  */
 
 import { async, inject, TestBed } from '@angular/core/testing';
-import { NbEmailPassAuthProvider } from './email-pass-auth.provider';
-import { NbAuthResult } from '../services/auth-result';
+import { NbDefaultAuthStrategy } from './default-strategy';
+import { NbAuthResult } from '../../services/auth-result';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 
-describe('email-pass-auth-provider', () => {
+describe('default-auth-strategy', () => {
 
-  let provider: NbEmailPassAuthProvider;
+  let strategy: NbDefaultAuthStrategy;
   let httpMock: HttpTestingController;
 
   const successResponse: any = {
@@ -40,18 +40,18 @@ describe('email-pass-auth-provider', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, RouterTestingModule],
       providers: [
-        { provide: NbEmailPassAuthProvider, useClass: NbEmailPassAuthProvider },
+        { provide: NbDefaultAuthStrategy, useClass: NbDefaultAuthStrategy },
       ],
     });
   });
 
   beforeEach(async(inject(
-    [NbEmailPassAuthProvider, HttpTestingController],
-    (_provider, _httpMock) => {
-      provider = _provider;
+    [NbDefaultAuthStrategy, HttpTestingController],
+    (_strategy, _httpMock) => {
+      strategy = _strategy;
       httpMock = _httpMock;
 
-      provider.setConfig({});
+      strategy.setConfig({});
     },
   )));
 
@@ -62,11 +62,11 @@ describe('email-pass-auth-provider', () => {
   describe('out of the box', () => {
 
     beforeEach(() => {
-      provider.setConfig({});
+      strategy.setConfig({});
     });
 
     it('authenticate success', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
@@ -85,7 +85,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate fail', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(false);
@@ -104,7 +104,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register success', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
@@ -122,7 +122,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register fail', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(false);
@@ -141,7 +141,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword success', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
@@ -159,7 +159,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword fail', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(false);
@@ -178,7 +178,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword success', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
@@ -196,7 +196,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword fail', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(false);
@@ -214,7 +214,7 @@ describe('email-pass-auth-provider', () => {
         .flush(successResponse, { status: 401, statusText: 'Unauthorized' });
     });
     it('logout success', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
@@ -232,7 +232,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('logout fail', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(false);
@@ -255,7 +255,7 @@ describe('email-pass-auth-provider', () => {
   describe('always fail', () => {
 
     beforeEach(() => {
-      provider.setConfig({
+      strategy.setConfig({
         login: {
           alwaysFail: true,
         },
@@ -275,7 +275,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate fail', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(true);
@@ -289,7 +289,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register fail', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(true);
@@ -303,7 +303,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword fail', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(true);
@@ -317,7 +317,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword fail', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(true);
@@ -331,7 +331,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('logout fail', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(true);
@@ -349,7 +349,7 @@ describe('email-pass-auth-provider', () => {
   describe('custom endpoint', () => {
 
     beforeEach(() => {
-      provider.setConfig({
+      strategy.setConfig({
         login: {
           endpoint: 'new',
         },
@@ -369,7 +369,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -383,7 +383,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -397,7 +397,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -411,7 +411,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -425,7 +425,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('logout', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -443,13 +443,13 @@ describe('email-pass-auth-provider', () => {
   describe('custom base endpoint', () => {
 
     beforeEach(() => {
-      provider.setConfig({
+      strategy.setConfig({
         baseEndpoint: '/api/auth/custom/',
       });
     });
 
     it('authenticate', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -463,7 +463,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -477,7 +477,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -491,7 +491,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -505,7 +505,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('logout', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -523,7 +523,7 @@ describe('email-pass-auth-provider', () => {
   describe('custom method', () => {
 
     beforeEach(() => {
-      provider.setConfig({
+      strategy.setConfig({
         login: {
           method: 'get',
         },
@@ -543,7 +543,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -557,7 +557,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -571,7 +571,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -585,7 +585,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -599,7 +599,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('logout', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -623,7 +623,7 @@ describe('email-pass-auth-provider', () => {
 
     beforeEach(() => {
 
-      provider.setConfig({
+      strategy.setConfig({
         login: {
           redirect,
         },
@@ -643,7 +643,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate success', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.success);
@@ -656,7 +656,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate fail', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.failure);
@@ -669,7 +669,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register success', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.success);
@@ -682,7 +682,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register fail', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.failure);
@@ -695,7 +695,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword success', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.success);
@@ -708,7 +708,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword fail', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.failure);
@@ -721,7 +721,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword success', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.success);
@@ -734,7 +734,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword fail', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.failure);
@@ -747,7 +747,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('logout success', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.success);
@@ -760,7 +760,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('logout fail', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getRedirect()).toBe(redirect.failure);
@@ -783,7 +783,7 @@ describe('email-pass-auth-provider', () => {
 
     beforeEach(() => {
 
-      provider.setConfig({
+      strategy.setConfig({
         login: {
           ...messages,
         },
@@ -803,7 +803,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate success', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getMessages()).toEqual(messages.defaultMessages);
@@ -816,7 +816,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate fail', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getErrors()).toEqual(messages.defaultErrors);
@@ -829,7 +829,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register success', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getMessages()).toEqual(messages.defaultMessages);
@@ -842,7 +842,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register fail', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getErrors()).toEqual(messages.defaultErrors);
@@ -855,7 +855,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword success', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getMessages()).toEqual(messages.defaultMessages);
@@ -868,7 +868,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('requestPassword fail', (done: DoneFn) => {
-      provider.requestPassword(loginData)
+      strategy.requestPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getErrors()).toEqual(messages.defaultErrors);
@@ -881,7 +881,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword success', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getMessages()).toEqual(messages.defaultMessages);
@@ -894,7 +894,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('resetPassword fail', (done: DoneFn) => {
-      provider.resetPassword(loginData)
+      strategy.resetPassword(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getErrors()).toEqual(messages.defaultErrors);
@@ -907,7 +907,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('logout success', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getMessages()).toEqual(messages.defaultMessages);
@@ -920,7 +920,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('logout fail', (done: DoneFn) => {
-      provider.logout()
+      strategy.logout()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.getErrors()).toEqual(messages.defaultErrors);
@@ -937,7 +937,7 @@ describe('email-pass-auth-provider', () => {
   describe('custom token key', () => {
 
     beforeEach(() => {
-      provider.setConfig({
+      strategy.setConfig({
         token: {
           key: 'token',
         },
@@ -945,7 +945,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -960,7 +960,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -979,7 +979,7 @@ describe('email-pass-auth-provider', () => {
   describe('custom token extractor', () => {
 
     beforeEach(() => {
-      provider.setConfig({
+      strategy.setConfig({
         token: {
           getter: (module: string, res: HttpResponse<Object>) => res.body['token'],
         },
@@ -987,7 +987,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -1002,7 +1002,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -1021,7 +1021,7 @@ describe('email-pass-auth-provider', () => {
   describe('custom message key', () => {
 
     beforeEach(() => {
-      provider.setConfig({
+      strategy.setConfig({
         token: {
           key: 'token',
         },
@@ -1035,7 +1035,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate success', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -1050,7 +1050,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate fail', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(true);
@@ -1065,7 +1065,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register success', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -1080,7 +1080,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register fail', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(true);
@@ -1099,7 +1099,7 @@ describe('email-pass-auth-provider', () => {
   describe('custom message extractor', () => {
 
     beforeEach(() => {
-      provider.setConfig({
+      strategy.setConfig({
         token: {
           key: 'token',
         },
@@ -1113,7 +1113,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate success', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -1128,7 +1128,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('authenticate fail', (done: DoneFn) => {
-      provider.authenticate(loginData)
+      strategy.authenticate(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(true);
@@ -1143,7 +1143,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register success', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -1158,7 +1158,7 @@ describe('email-pass-auth-provider', () => {
     });
 
     it('register fail', (done: DoneFn) => {
-      provider.register(loginData)
+      strategy.register(loginData)
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(true);

--- a/src/framework/auth/strategies/default/default-strategy.ts
+++ b/src/framework/auth/strategies/default/default-strategy.ts
@@ -12,10 +12,10 @@ import { switchMap } from 'rxjs/operators/switchMap';
 import { map } from 'rxjs/operators/map';
 import { catchError } from 'rxjs/operators/catchError';
 
-import { NgEmailPassAuthProviderConfig } from './email-pass-auth.options';
-import { NbAuthResult } from '../services/auth-result';
-import { NbAbstractAuthProvider } from './abstract-auth.provider';
-import { getDeepFromObject } from '../helpers';
+import { NbDefaultAuthStrategyOptions } from './default-strategy-options';
+import { NbAuthResult } from '../../services/auth-result';
+import { NbAuthStrategy } from '../auth-strategy';
+import { getDeepFromObject } from '../../helpers';
 
 /**
  * The most common authentication provider for email/password strategy.
@@ -105,14 +105,14 @@ import { getDeepFromObject } from '../helpers';
  *
  * // Note, there is no need to copy over the whole object to change the settings you need.
  * // Also, this.getConfigValue call won't work outside ofthe default config declaration
- * // (which is inside of the `NbEmailPassAuthProvider` class), so you have to replace it with a custom helper function
+ * // (which is inside of the `NbDefaultAuthStrategy` class), so you have to replace it with a custom helper function
  * // if you need it.
  * ```
  */
 @Injectable()
-export class NbEmailPassAuthProvider extends NbAbstractAuthProvider {
+export class NbDefaultAuthStrategy extends NbAuthStrategy {
 
-  protected defaultConfig: NgEmailPassAuthProviderConfig = {
+  protected defaultConfig: NbDefaultAuthStrategyOptions = {
     baseEndpoint: '/api/auth/',
     login: {
       alwaysFail: false,
@@ -408,7 +408,7 @@ export class NbEmailPassAuthProvider extends NbAbstractAuthProvider {
       const token = this.getConfigValue('token.getter')(module, res);
       if (!token) {
         const key = this.getConfigValue('token.key');
-        console.warn(`NbEmailPassAuthProvider:
+        console.warn(`NbDefaultAuthStrategy:
                           Token is not provided under '${key}' key
                           with getter '${this.getConfigValue('token.getter')}', check your auth configuration.`);
 

--- a/src/framework/auth/strategies/dummy/dummy-strategy-options.ts
+++ b/src/framework/auth/strategies/dummy/dummy-strategy-options.ts
@@ -3,9 +3,8 @@
  * Copyright Akveo. All Rights Reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
-export * from './auth.options';
-export * from './auth.module';
 
-export * from './components';
-export * from './services';
-export * from './strategies';
+export interface NbDummyAuthStrategyOptions {
+  delay?: number;
+  alwaysFail?: boolean;
+}

--- a/src/framework/auth/strategies/dummy/dummy-strategy.ts
+++ b/src/framework/auth/strategies/dummy/dummy-strategy.ts
@@ -4,18 +4,15 @@ import { Observable } from 'rxjs/Observable';
 import { of as observableOf } from 'rxjs/observable/of';
 import { delay } from 'rxjs/operators/delay';
 
-import { NbAbstractAuthProvider } from './abstract-auth.provider';
-import { NbAuthResult } from '../services/auth-result';
+import { NbAuthStrategy } from '../auth-strategy';
+import { NbAuthResult } from '../../services/auth-result';
+import { NbDummyAuthStrategyOptions } from './dummy-strategy-options';
 
-export interface NbDummyAuthProviderConfig {
-  delay?: number;
-  alwaysFail?: boolean;
-}
 
 @Injectable()
-export class NbDummyAuthProvider extends NbAbstractAuthProvider {
+export class NbDummyAuthStrategy extends NbAuthStrategy {
 
-  protected defaultConfig: NbDummyAuthProviderConfig = {
+  protected defaultConfig: NbDummyAuthStrategyOptions = {
     delay: 1000,
   };
 

--- a/src/framework/auth/strategies/index.ts
+++ b/src/framework/auth/strategies/index.ts
@@ -1,0 +1,4 @@
+export * from './auth-strategy';
+export * from './dummy/dummy-strategy';
+export * from './default/default-strategy';
+export * from './default/default-strategy-options';


### PR DESCRIPTION
BREAKING CHANGE:
- term auth `provider` renamed to `strategy` to eliminate intersection with Angular providers
- `NbDummyAuthProvider` renamed to `NbDummyAuthStrategy`
- `NbEmailPassAuthProvider` renamed to `NbDefaultAuthStrategy`
- `NbAbstractAuthProvider` renamed to `NbAuthStrategy`
- `NbAuthModule.forRoot({ forms.login.provider })` changed to `NbAuthModule.forRoot({ forms.login.strategy })`
```
`NbAuthModule.forRoot({
  forms: {
     login: {
       strategy: 'email', // provider -> strategy
     },
  },
})`

```

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
