### PR TITLE
feat(auth): field errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ testem.log
 Thumbs.db
 debug.log
 local.log
+yarn-error.log

--- a/src/framework/auth/components/abstract-auth-component.class.ts
+++ b/src/framework/auth/components/abstract-auth-component.class.ts
@@ -1,0 +1,34 @@
+import {FieldErrors} from '../services/auth-result';
+import {NB_AUTH_OPTIONS} from '../auth.options';
+import {getDeepFromObject} from '../helpers';
+import {Inject} from '@angular/core';
+
+export abstract class AbstractAuthComponent {
+  redirectDelay: number = 0;
+  showMessages: any = {};
+  provider: string = '';
+
+  errors: string[] = [];
+  fieldErrors: FieldErrors = {};
+  messages: string[] = [];
+  user: any = {};
+  submitted: boolean = false;
+
+
+  constructor(@Inject(NB_AUTH_OPTIONS) protected config = {}) {}
+
+  getConfigValue(key: string): any {
+    return getDeepFromObject(this.config, key, null);
+  }
+
+  /**
+   * If user change the field with the backend error, it should dissapear,
+   * otherwise it looks confusing.
+   * @param name
+   */
+  clearFieldErrors(name) {
+    if (name in this.fieldErrors) {
+      delete this.fieldErrors[name];
+    }
+  }
+}

--- a/src/framework/auth/components/register/register.component.ts
+++ b/src/framework/auth/components/register/register.component.ts
@@ -6,10 +6,10 @@
 import { Component, Inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { NB_AUTH_OPTIONS, NbAuthSocialLink } from '../../auth.options';
-import { getDeepFromObject } from '../../helpers';
 
 import { NbAuthService } from '../../services/auth.service';
 import { NbAuthResult } from '../../services/auth-result';
+import {AbstractAuthComponent} from '../abstract-auth-component.class';
 
 
 @Component({
@@ -35,6 +35,7 @@ import { NbAuthResult } from '../../services/auth-result';
           <label for="input-name" class="sr-only">Full name</label>
           <input name="fullName" [(ngModel)]="user.fullName" id="input-name" #fullName="ngModel"
                  class="form-control" placeholder="Full name"
+                 (keyup)="clearFieldErrors('fullName')"
                  [class.form-control-danger]="fullName.invalid && fullName.touched"
                  [required]="getConfigValue('forms.validation.fullName.required')"
                  [minlength]="getConfigValue('forms.validation.fullName.minLength')"
@@ -51,12 +52,16 @@ import { NbAuthResult } from '../../services/auth-result';
             to {{getConfigValue('forms.validation.password.maxLength')}}
             characters
           </small>
+          <small class="form-text error" *ngIf="fieldErrors.fullName?.length">
+            {{fieldErrors.password[0]}}
+          </small>
         </div>
 
         <div class="form-group">
           <label for="input-email" class="sr-only">Email address</label>
           <input name="email" [(ngModel)]="user.email" id="input-email" #email="ngModel"
                  class="form-control" placeholder="Email address" pattern=".+@.+\..+"
+                 (keyup)="clearFieldErrors('email')"
                  [class.form-control-danger]="email.invalid && email.touched"
                  [required]="getConfigValue('forms.validation.email.required')">
           <small class="form-text error" *ngIf="email.invalid && email.touched && email.errors?.required">
@@ -66,12 +71,16 @@ import { NbAuthResult } from '../../services/auth-result';
                  *ngIf="email.invalid && email.touched && email.errors?.pattern">
             Email should be the real one!
           </small>
+          <small class="form-text error" *ngIf="fieldErrors.email?.length">
+            {{fieldErrors.email[0]}}
+          </small>
         </div>
 
         <div class="form-group">
           <label for="input-password" class="sr-only">Password</label>
           <input name="password" [(ngModel)]="user.password" type="password" id="input-password"
                  class="form-control" placeholder="Password" #password="ngModel"
+                 (keyup)="clearFieldErrors('password')"
                  [class.form-control-danger]="password.invalid && password.touched"
                  [required]="getConfigValue('forms.validation.password.required')"
                  [minlength]="getConfigValue('forms.validation.password.minLength')"
@@ -87,6 +96,9 @@ import { NbAuthResult } from '../../services/auth-result';
             to {{ getConfigValue('forms.validation.password.maxLength') }}
             characters
           </small>
+          <small class="form-text error" *ngIf="fieldErrors.password?.length">
+            {{fieldErrors.password[0]}}
+          </small>
         </div>
 
         <div class="form-group">
@@ -94,6 +106,7 @@ import { NbAuthResult } from '../../services/auth-result';
           <input
             name="rePass" [(ngModel)]="user.confirmPassword" type="password" id="input-re-password"
             class="form-control" placeholder="Confirm Password" #rePass="ngModel"
+            (keyup)="clearFieldErrors('confirmPassword')"
             [class.form-control-danger]="(rePass.invalid || password.value != rePass.value) && rePass.touched"
             [required]="getConfigValue('forms.validation.password.required')">
           <small class="form-text error"
@@ -104,6 +117,9 @@ import { NbAuthResult } from '../../services/auth-result';
             class="form-text error"
             *ngIf="rePass.touched && password.value != rePass.value && !rePass.errors?.required">
             Password does not match the confirm password.
+          </small>
+          <small class="form-text error" *ngIf="fieldErrors.confirmPassword?.length">
+            {{fieldErrors.confirmPassword[0]}}
           </small>
         </div>
 
@@ -147,22 +163,15 @@ import { NbAuthResult } from '../../services/auth-result';
     </nb-auth-block>
   `,
 })
-export class NbRegisterComponent {
+export class NbRegisterComponent extends AbstractAuthComponent {
 
-  redirectDelay: number = 0;
-  showMessages: any = {};
-  provider: string = '';
 
-  submitted = false;
-  errors: string[] = [];
-  messages: string[] = [];
-  user: any = {};
   socialLinks: NbAuthSocialLink[] = [];
 
   constructor(protected service: NbAuthService,
               @Inject(NB_AUTH_OPTIONS) protected config = {},
               protected router: Router) {
-
+    super(config);
     this.redirectDelay = this.getConfigValue('forms.register.redirectDelay');
     this.showMessages = this.getConfigValue('forms.register.showMessages');
     this.provider = this.getConfigValue('forms.register.provider');
@@ -171,6 +180,7 @@ export class NbRegisterComponent {
 
   register(): void {
     this.errors = this.messages = [];
+    this.fieldErrors = {};
     this.submitted = true;
 
     this.service.register(this.provider, this.user).subscribe((result: NbAuthResult) => {
@@ -179,6 +189,7 @@ export class NbRegisterComponent {
         this.messages = result.getMessages();
       } else {
         this.errors = result.getErrors();
+        this.fieldErrors = result.getFieldErrors();
       }
 
       const redirect = result.getRedirect();
@@ -190,7 +201,4 @@ export class NbRegisterComponent {
     });
   }
 
-  getConfigValue(key: string): any {
-    return getDeepFromObject(this.config, key, null);
-  }
 }

--- a/src/framework/auth/helpers.spec.ts
+++ b/src/framework/auth/helpers.spec.ts
@@ -1,0 +1,12 @@
+import {getDeepFromObject} from '@nebular/auth/helpers';
+
+
+describe('getDeepFromObject', () => {
+  it('extract the the value', () => {
+    expect(getDeepFromObject({result: {data: 1}}, 'result.data', 2)).toBe(1);
+  });
+
+  it('extract the the whole object', () => {
+    expect(getDeepFromObject({result: {data: 1}}, '', 2)).toEqual({result: {data: 1}});
+  });
+});

--- a/src/framework/auth/helpers.ts
+++ b/src/framework/auth/helpers.ts
@@ -117,9 +117,16 @@ function deepCloneArray(arr: any[]): any {
 
 // getDeepFromObject({result: {data: 1}}, 'result.data', 2); // returns 1
 export function getDeepFromObject(object = {}, name: string, defaultValue?: any) {
-  const keys = name.split('.');
   // clone the object
   let level = deepExtend({}, object || {});
+
+  // add possibility to get the whole object from the config definition
+  if (name === '') {
+    return level;
+  }
+
+  const keys = name.split('.');
+
   keys.forEach((k) => {
     if (level && typeof level[k] !== 'undefined') {
       level = level[k];

--- a/src/framework/auth/providers/abstract-auth.provider.ts
+++ b/src/framework/auth/providers/abstract-auth.provider.ts
@@ -9,6 +9,10 @@ export abstract class NbAbstractAuthProvider {
   protected defaultConfig: any = {};
   protected config: any = {};
 
+  getDefaultConfig() {
+    return this.defaultConfig;
+  }
+
   setConfig(config: any): void {
     this.config = deepExtend({}, this.defaultConfig, config);
   }

--- a/src/framework/auth/providers/django-rest-auth.provider.ts
+++ b/src/framework/auth/providers/django-rest-auth.provider.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright Akveo. All Rights Reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpErrorResponse} from '@angular/common/http';
+import {ActivatedRoute} from '@angular/router';
+import {FieldErrors} from '../services';
+import {deepExtend} from '../helpers';
+import {NbEmailPassAuthProvider} from './email-pass-auth.provider';
+
+
+/**
+ * Provider for django-rest-auth
+ * See https://django-rest-auth.readthedocs.io/en/latest/
+ */
+@Injectable()
+export class NbDjangoRestAuthProvider extends NbEmailPassAuthProvider {
+
+  protected extraDefaultConfig = {
+    baseEndpoint: '/api/auth/',
+    login: {
+      endpoint: 'login/',
+      fieldErrorsMap: {
+        email: 'email',
+        password: 'password',
+      },
+    },
+    register: {
+      endpoint: 'registration/',
+      fieldErrorsMap: {
+        username: 'fullName',
+        email: 'email',
+        password1: 'password',
+        password2: 'rePass',
+      },
+    },
+    logout: {
+      method: 'post',
+      endpoint: 'logout/',
+    },
+    requestPass: {
+      endpoint: 'password/reset/',
+      fieldErrorsMap: {
+        email: 'email',
+      },
+    },
+    resetPass: {
+      endpoint: 'password/reset/confirm/',
+      method: 'post',
+      resetPasswordTokenKey: 'token',
+      fieldErrorsMap: {
+        new_password1: 'password',
+        new_password2: 'confirmPassword',
+      },
+    },
+    errors: {
+      key: 'non_field_errors',
+    },
+    fieldErrors: {
+      key: '',
+    },
+    messages: {
+      key: 'detail',
+    },
+    token: {
+      key: 'key',
+    },
+  };
+
+
+  constructor(protected http: HttpClient, protected route: ActivatedRoute) {
+    super(http, route);
+    this.defaultConfig = deepExtend({}, this.getDefaultConfig(), this.extraDefaultConfig);
+  }
+
+  protected getErrorMessages(module: string, response: HttpErrorResponse): [string[], FieldErrors] {
+    let errors = [];
+    let fieldErrors = {};
+    [errors, fieldErrors] = super.getErrorMessages(module, response);
+
+    const fieldErrorsMap = this.getConfigValue(`${module}.fieldErrorsMap`);
+
+    let mappedFieldErrors = {};
+    if (fieldErrors && fieldErrorsMap) {
+      for (const k in fieldErrors) {
+        if (!fieldErrors.hasOwnProperty(k)) {
+          continue;
+        }
+
+        if (k === 'non_field_errors') {
+          continue;
+        }
+
+        if (k in fieldErrorsMap) {
+          mappedFieldErrors[fieldErrorsMap[k]] = fieldErrors[k];
+        } else {
+          errors.push(`${k}: ${fieldErrors[k]}`);
+        }
+      }
+    } else {
+      mappedFieldErrors = fieldErrors;
+    }
+
+    return [errors, mappedFieldErrors];
+  }
+
+  protected modifyResetPasswordData(data) {
+    const tokenKey = this.getConfigValue('resetPass.resetPasswordTokenKey');
+    const params = this.route.firstChild.firstChild.snapshot.params;
+    return {
+      new_password1: data['password'],
+      new_password2: data['confirmPassword'],
+      [tokenKey]: params[tokenKey],
+      uid: params['uid'],
+    };
+  }
+
+  protected modifyRegisterData(data) {
+    return {
+      'username': data['fullName'],
+      'email': data['email'],
+      'password1': data['password'],
+      'password2': data['confirmPassword'],
+    }
+  }
+
+}

--- a/src/framework/auth/providers/django-rest-auth.spec.ts
+++ b/src/framework/auth/providers/django-rest-auth.spec.ts
@@ -1,0 +1,375 @@
+/**
+ * @license
+ * Copyright Akveo. All Rights Reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { async, inject, TestBed } from '@angular/core/testing';
+import { NbEmailPassAuthProvider } from './email-pass-auth.provider';
+import { NbAuthResult } from '../services/auth-result';
+
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import {NbDjangoRestAuthProvider} from '@nebular/auth/providers/django-rest-auth.provider';
+import {ActivatedRoute} from '@angular/router';
+import {TestRequest} from '@angular/common/http/testing/src/request';
+
+describe('django-rest-auth-provider', () => {
+
+  let provider: NbEmailPassAuthProvider;
+  let httpMock: HttpTestingController;
+
+  const successResponse: any = {
+    data: {
+      'token': 'token',
+      'messages': ['Success message'],
+      'errors': ['Error message'],
+    },
+  };
+
+  const loginData = { email: 'test@test.com', password: '123456' };
+  const registerData = {
+    'fullName': 'John Smith',
+    'email': 'test@test.com',
+    'password': '123',
+    'confirmPassword': '123',
+  };
+  const requestPasswordData = {email: 'test@test.com'};
+  const resetPasswordData = {password: '123', confirmPassword: '123'};
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: NbDjangoRestAuthProvider, useClass: NbDjangoRestAuthProvider },
+        { provide: ActivatedRoute, useValue: {
+          firstChild: {
+            firstChild: {
+              snapshot: {
+                params: {
+                  uid: 'xxx',
+                  token: 'yyy',
+                },
+              },
+            },
+          },
+        }},
+      ],
+    });
+  });
+
+  beforeEach(async(inject(
+    [NbDjangoRestAuthProvider, HttpTestingController],
+    (_provider, _httpMock) => {
+      provider = _provider;
+      httpMock = _httpMock;
+
+      provider.setConfig({});
+    },
+  )));
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('out of the box', () => {
+
+    beforeEach(() => {
+      provider.setConfig({});
+    });
+
+    it('authenticate success', (done: DoneFn) => {
+      let request: TestRequest;
+      provider.authenticate(loginData)
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(true);
+          expect(result.isFailure()).toBe(false);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual(provider.getConfigValue('login.defaultMessages'));
+          expect(result.getErrors()).toEqual([]); // no error message, response is success
+          expect(result.getFieldErrors()).toEqual({});
+          expect(result.getRawToken()).toEqual('xxx');
+          expect(result.getRedirect()).toEqual('/');
+
+          expect(request.request.body).toEqual(loginData);
+          done();
+        });
+
+      request = httpMock.expectOne('/api/auth/login/');
+      request.flush({
+        'key': 'xxx',
+      });
+    });
+
+    it('authenticate fail', (done: DoneFn) => {
+      provider.authenticate(loginData)
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(false);
+          expect(result.isFailure()).toBe(true);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual([]);
+          expect(result.getErrors()).toEqual(['Unable to log in with provided credentials.']);
+          expect(result.getRawToken()).toBeUndefined();
+          expect(result.getRedirect()).toEqual(null);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/login/').flush(
+        {
+          'non_field_errors': [
+            'Unable to log in with provided credentials.',
+          ],
+        },
+        { status: 401, statusText: 'Unauthorized' },
+      );
+    });
+
+    it('register success', (done: DoneFn) => {
+      let request: TestRequest;
+      provider.register(registerData)
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(true);
+          expect(result.isFailure()).toBe(false);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual(provider.getConfigValue('register.defaultMessages'));
+          expect(result.getErrors()).toEqual([]);
+          expect(result.getFieldErrors()).toEqual({});
+          expect(result.getRawToken()).toEqual('xxx');
+          expect(result.getRedirect()).toEqual('/');
+
+          expect(request.request.body).toEqual({
+            'username': 'John Smith',
+            'email': 'test@test.com',
+            'password1': '123',
+            'password2': '123',
+          });
+          done();
+        });
+
+      request = httpMock.expectOne('/api/auth/registration/');
+      request.flush({
+        'key': 'xxx',
+      });
+    });
+
+    it('register fail', (done: DoneFn) => {
+      provider.register(registerData)
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(false);
+          expect(result.isFailure()).toBe(true);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual([]);
+          expect(result.getErrors()).toEqual(provider.getConfigValue('register.defaultErrors'));
+          expect(result.getFieldErrors()).toEqual({
+            'fullName': [
+              'This field may not be blank.',
+            ],
+            'email': [
+              'Enter a valid email address.',
+            ],
+            'password': [
+              'This password is too short. It must contain at least 8 characters.',
+              'This password is entirely numeric.',
+            ],
+            'rePass': [
+              'This field may not be blank.',
+            ],
+          });
+          expect(result.getRawToken()).toBeUndefined();
+          expect(result.getRedirect()).toEqual(null);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/registration/').flush(
+        {
+          'username': [
+            'This field may not be blank.',
+          ],
+          'email': [
+            'Enter a valid email address.',
+          ],
+          'password1': [
+            'This password is too short. It must contain at least 8 characters.',
+            'This password is entirely numeric.',
+          ],
+          'password2': [
+            'This field may not be blank.',
+          ],
+        },
+        { status: 401, statusText: 'Unauthorized' },
+      );
+    });
+
+    it('requestPassword success', (done: DoneFn) => {
+      let request: TestRequest;
+      provider.requestPassword(requestPasswordData)
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(true);
+          expect(result.isFailure()).toBe(false);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual(['Password reset e-mail has been sent.']);
+          expect(result.getErrors()).toEqual([]); // no error message, response is success
+          expect(result.getRawToken()).toBeUndefined();
+          expect(result.getRedirect()).toEqual('/');
+
+          expect(request.request.body).toEqual({email: 'test@test.com'});
+          done();
+        });
+
+      request = httpMock.expectOne('/api/auth/password/reset/');
+      request.flush({'detail': 'Password reset e-mail has been sent.'});
+    });
+
+    it('requestPassword fail', (done: DoneFn) => {
+      provider.requestPassword(requestPasswordData)
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(false);
+          expect(result.isFailure()).toBe(true);
+          expect(result.getToken()).toBeUndefined();
+          expect(result.getMessages()).toEqual([]);
+          expect(result.getErrors()).toEqual(provider.getConfigValue('requestPass.defaultErrors'));
+          expect(result.getFieldErrors()).toEqual({
+            'email': [
+              'Enter a valid email address.',
+            ],
+          });
+          expect(result.getRawToken()).toBeUndefined();
+          expect(result.getRedirect()).toEqual(null);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/password/reset/').flush(
+        {
+          'email': [
+            'Enter a valid email address.',
+          ],
+        },
+        { status: 401, statusText: 'Unauthorized' },
+      );
+    });
+
+    it('resetPassword success', (done: DoneFn) => {
+      let request: TestRequest;
+      provider.resetPassword(resetPasswordData)
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(true);
+          expect(result.isFailure()).toBe(false);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual(['Password has been reset with the new password.']);
+          expect(result.getErrors()).toEqual([]); // no error message, response is success
+          expect(result.getRawToken()).toBeUndefined();
+          expect(result.getRedirect()).toEqual('/');
+
+          expect(request.request.body).toEqual({
+            new_password1: '123',
+            new_password2: '123',
+            uid: 'xxx',
+            token: 'yyy',
+          });
+          done();
+        });
+
+      request = httpMock.expectOne('/api/auth/password/reset/confirm/');
+      request.flush(
+        {
+          'detail': 'Password has been reset with the new password.',
+        },
+      );
+    });
+
+    it('resetPassword fail', (done: DoneFn) => {
+      provider.resetPassword(resetPasswordData)
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(false);
+          expect(result.isFailure()).toBe(true);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual([]);
+          expect(result.getErrors()).toEqual([
+            ...provider.getConfigValue('resetPass.defaultErrors'),
+            'uid: Invalid value',
+          ]);
+          expect(result.getFieldErrors()).toEqual({
+            'password': [
+              'This field may not be blank.',
+            ],
+            'confirmPassword': [
+              'This field may not be blank.',
+            ],
+          });
+          expect(result.getRawToken()).toBeUndefined();
+          expect(result.getRedirect()).toEqual(null);
+
+          done();
+        });
+
+      const request = httpMock.expectOne('/api/auth/password/reset/confirm/');
+      request.flush(
+        {
+          'new_password1': [
+            'This field may not be blank.',
+          ],
+          'new_password2': [
+            'This field may not be blank.',
+          ],
+          'uid': [
+            'Invalid value',
+          ],
+        },
+        { status: 401, statusText: 'Unauthorized' },
+      );
+    });
+    it('logout success', (done: DoneFn) => {
+      provider.logout()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(true);
+          expect(result.isFailure()).toBe(false);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual(['Successfully logged out.']);
+          expect(result.getErrors()).toEqual([]);
+          expect(result.getRawToken()).toBeUndefined();
+          expect(result.getRedirect()).toEqual('/');
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/logout/').flush(
+        {
+          'detail': 'Successfully logged out.',
+        },
+      );
+    });
+
+    it('logout fail', (done: DoneFn) => {
+      provider.logout()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(false);
+          expect(result.isFailure()).toBe(true);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual([]);
+          expect(result.getErrors()).toEqual(provider.getConfigValue('resetPass.defaultErrors'));
+          expect(result.getRawToken()).toBeUndefined();
+          expect(result.getRedirect()).toEqual(null);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/logout/')
+        .flush(successResponse, { status: 401, statusText: 'Unauthorized' });
+    });
+
+  });
+
+});

--- a/src/framework/auth/providers/dummy-auth.provider.ts
+++ b/src/framework/auth/providers/dummy-auth.provider.ts
@@ -57,13 +57,19 @@ export class NbDummyAuthProvider extends NbAbstractAuthProvider {
   protected createDummyResult(data?: any): NbAuthResult {
     if (this.getConfigValue('alwaysFail')) {
       // TODO we dont call tokenService clear during logout in case result is not success
-      return new NbAuthResult(false,
-        this.createFailResponse(data),
-        null,
-        ['Something went wrong.']);
+      return new NbAuthResult({
+          success: false,
+          response: this.createFailResponse(data),
+          errors: ['Something went wrong.'],
+      });
     }
 
     // TODO is it missed messages here, is it token should be defined
-    return new NbAuthResult(true, this.createSuccessResponse(data), '/', ['Successfully logged in.']);
+    return new NbAuthResult({
+      success: true,
+      response: this.createSuccessResponse(data),
+      redirect: '/',
+      messages: ['Successfully logged in.'],
+    });
   }
 }

--- a/src/framework/auth/providers/email-pass-auth.options.ts
+++ b/src/framework/auth/providers/email-pass-auth.options.ts
@@ -39,6 +39,10 @@ export interface NgEmailPassAuthProviderConfig {
     key?: string;
     getter?: Function;
   };
+  fieldErrors?: {
+    key?: string;
+    getter?: Function;
+  };
   messages?: {
     key?: string;
     getter?: Function;

--- a/src/framework/auth/services/auth-result.ts
+++ b/src/framework/auth/services/auth-result.ts
@@ -1,18 +1,49 @@
 import { NbAuthToken } from './token/token';
 
+export interface FieldErrors {
+  [key: string]: string[]
+}
+
 export class NbAuthResult {
 
+  protected success: boolean;
+  protected response: any;
+  protected redirect: any = null;
   protected token: NbAuthToken;
   protected rawToken: string;
   protected errors: string[] = [];
   protected messages: string[] = [];
+  protected fieldErrors: FieldErrors = {};
 
-  constructor(protected success: boolean,
-              protected response?: any,
-              protected redirect?: any,
-              errors?: any,
-              messages?: any,
-              rawToken?: string) {
+
+  /**
+   *
+   * @param {boolean} success
+   * @param {any} response
+   * @param {any} redirect
+   * @param {any} errors
+   * @param {FieldErrors} fieldErrors
+   * @param {any} messages
+   * @param {string} rawToken
+   */
+  constructor(
+    {
+      success,
+      response,
+      redirect,
+      errors,
+      fieldErrors,
+      messages,
+      rawToken,
+    }: {
+      success: boolean,
+      response?: any,
+      redirect?: any,
+      errors?: any,
+      fieldErrors?: FieldErrors,
+      messages?: any,
+      rawToken?: string,
+    }) {
 
     this.errors = this.errors.concat([errors]);
     if (errors instanceof Array) {
@@ -24,7 +55,23 @@ export class NbAuthResult {
       this.messages = messages;
     }
 
-    this.rawToken = rawToken;
+    this.success = success;
+
+    if (response) {
+      this.response = response;
+    }
+
+    if (redirect) {
+      this.redirect = redirect;
+    }
+
+    if (fieldErrors) {
+      this.fieldErrors = fieldErrors;
+    }
+
+    if (rawToken) {
+      this.rawToken = rawToken;
+    }
   }
 
   setToken(token: NbAuthToken) {
@@ -50,6 +97,10 @@ export class NbAuthResult {
 
   getErrors(): string[] {
     return this.errors.filter(val => !!val);
+  }
+
+  getFieldErrors(): FieldErrors {
+    return this.fieldErrors;
   }
 
   getMessages(): string[] {

--- a/src/framework/auth/services/auth.spec.ts
+++ b/src/framework/auth/services/auth.spec.ts
@@ -33,35 +33,40 @@ describe('auth-service', () => {
   const replacedToken = nbCreateToken(NbAuthSimpleToken, replacedTokenValue);
   const emptyToken = nbCreateToken(NbAuthSimpleToken, null);
 
-  const failResult = new NbAuthResult(false,
-    resp401,
-    null,
-    ['Something went wrong.']);
+  const failResult = new NbAuthResult({
+    success: false,
+    response: resp401,
+    errors: ['Something went wrong.'],
+  });
 
-  const successResult = new NbAuthResult(true,
-    resp200,
-    '/',
-    [],
-    ['Successfully logged in.'],
-    testTokenValue);
+  const successResult = new NbAuthResult({
+    success: true,
+    response: resp200,
+    redirect: '/',
+    messages: ['Successfully logged in.'],
+    rawToken: testTokenValue,
+  });
 
-  const successLogoutResult = new NbAuthResult(true,
-    resp200,
-    '/',
-    [],
-    ['Successfully logged out.']);
+  const successLogoutResult = new NbAuthResult({
+    success: true,
+    response: resp200,
+    redirect: '/',
+    messages: ['Successfully logged out.'],
+  });
 
-  const successResetPasswordResult = new NbAuthResult(true,
-    resp200,
-    '/',
-    [],
-    ['Successfully reset password.']);
+  const successResetPasswordResult = new NbAuthResult({
+    success: true,
+    response: resp200,
+    redirect: '/',
+    messages: ['Successfully reset password.'],
+  });
 
-  const successRequestPasswordResult = new NbAuthResult(true,
-    resp200,
-    '/',
-    [],
-    ['Successfully requested password.']);
+  const successRequestPasswordResult = new NbAuthResult({
+    success: true,
+    response: resp200,
+    redirect: '/',
+    messages: ['Successfully requested password.'],
+  });
 
   beforeEach(() => {
     TestBed.configureTestingModule({


### PR DESCRIPTION
Add a possibility to add field errors (for backend validation purposes) like this:
![selection_274](https://user-images.githubusercontent.com/3356454/38421692-a7d43246-39b0-11e8-8eab-1fd8adcefb0c.png)

Also, there is an auth provider for Django Rest Auth:
https://django-rest-auth.readthedocs.io/en/latest/