### PR TITLE
Fullname Validation error text is showing the password validation tex…

### DIFF
--- a/src/framework/auth/components/register/register.component.ts
+++ b/src/framework/auth/components/register/register.component.ts
@@ -47,8 +47,8 @@ import { NbAuthResult } from '../../services/auth-result';
             class="form-text error"
             *ngIf="fullName.invalid && fullName.touched && (fullName.errors?.minlength || fullName.errors?.maxlength)">
             Full name should contains
-            from {{getConfigValue('forms.validation.password.minLength')}}
-            to {{getConfigValue('forms.validation.password.maxLength')}}
+            from {{getConfigValue('forms.validation.fullName.minLength')}}
+            to {{getConfigValue('forms.validation.fullName.maxLength')}}
             characters
           </small>
         </div>


### PR DESCRIPTION
…t instead of the fullname one

getConfigValue('forms.validation.password.minLength') to getConfigValue('forms.validation.fullName.minLength')
same for maxLength

### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
