### PR TITLE
refactor(auth): pass strategies through special `setup` method

### DIFF
--- a/docs/articles/auth-install.md
+++ b/docs/articles/auth-install.md
@@ -18,7 +18,8 @@ Let's assume that we need to setup email & password authentication based on Nebu
 
 `import { NbPasswordAuthStrategy, NbAuthModule } from '@nebular/auth';`
 
-3) Now, let's configure the module by specifying available strategies, in your case we add `NbPasswordAuthStrategy`:
+3) Now, let's configure the module by specifying available strategies, in your case we add `NbPasswordAuthStrategy`.
+To add a strategy we need to call static `setup` method to pass a list of options:
 
 ```typescript
 
@@ -27,14 +28,11 @@ Let's assume that we need to setup email & password authentication based on Nebu
    // ...
     
    NbAuthModule.forRoot({
-         strategies: {
-           email: {
-             service: NbPasswordAuthStrategy,
-             options: {
-              ...
-             },
-           },
-         },
+         strategies: [
+           NbPasswordAuthStrategy.setup({
+             name: 'email',
+           }),
+         ],
          forms: {},
        }), 
   ],

--- a/docs/articles/auth-strategy.md
+++ b/docs/articles/auth-strategy.md
@@ -24,14 +24,12 @@ We assume you already have the Auth module installed inside of your `*.module.ts
    // ...
     
    NbAuthModule.forRoot({
-         strategies: {
-           email: {
-             service: NbPasswordAuthStrategy,
-             options: {
-              ...
-             },
-           },
-         },
+         strategies: [
+           NbPasswordAuthStrategy.setup({
+             name: 'email',
+           }),
+         ],
+         forms: {},
        }), 
   ],
 });

--- a/docs/articles/auth-token.md
+++ b/docs/articles/auth-token.md
@@ -37,27 +37,27 @@ This line tells Angular to inject `NbAuthJWTToken` (instead of the default `NbAu
 We'll assume that our API returns a token as just `{token: 'some-jwt-token'}` not wrapping your response in the `data` property, let's tell that to Nebular:
 
 ```typescript
+
 @NgModule({
   imports: [
    // ...
     
    NbAuthModule.forRoot({
-         strategies: {
-           email: {
-             service: NbPasswordAuthStrategy,
-             options: {
-               ...
-                
-               token: {
-                 key: 'token', // this parameter tells Nebular where to look for the token
-               },
+         strategies: [
+           NbPasswordAuthStrategy.setup({
+             name: 'email',
+             
+             token: {
+               key: 'token', // this parameter tells Nebular where to look for the token
              },
-           },
-         },
+           }),
+         ],
+         forms: {},
        }), 
   ],
 });
-```  
+
+``` 
 
 
 3) Okay, let's use the token to extract a payload and show a username in the header. Open your `header.component.ts` and import the following services:

--- a/docs/articles/auth-ui.md
+++ b/docs/articles/auth-ui.md
@@ -21,14 +21,11 @@ Alongside with the strategies' configuration `AuthModule` also accepts a list of
    // ...
     
    NbAuthModule.forRoot({
-         strategies: {
-           email: {
-             service: NbPasswordAuthStrategy,
-             options: {
-              ...
-             },
-           },
-         },
+         strategies: [
+           NbPasswordAuthStrategy.setup({
+             name: 'email',
+           }),
+         ],
          forms: {},
        }), 
   ],
@@ -122,44 +119,41 @@ So, for instance, to remove the redirectDelay setting and disable the success me
    // ...
     
    NbAuthModule.forRoot({
-         strategies: {
-           email: {
-             service: NbPasswordAuthStrategy,
-             options: {
-              ...
+         strategies: [
+           NbPasswordAuthStrategy.setup({
+             name: 'email',
+           }),
+         ],
+         forms: {
+           login: {
+             redirectDelay: 0,
+             showMessages: {
+               success: true,
              },
            },
+           register: {
+             redirectDelay: 0,
+             showMessages: {
+               success: true,
+             },
+           },
+           requestPassword: {
+             redirectDelay: 0,
+             showMessages: {
+               success: true,
+             },
+           },
+           resetPassword: {
+             redirectDelay: 0,
+             showMessages: {
+               success: true,
+             },
+           },
+           logout: {
+             redirectDelay: 0,
+           },
          },
-         forms: {
-          login: {
-            redirectDelay: 0,
-            showMessages: {
-              success: true,
-            },
-          },
-          register: {
-            redirectDelay: 0,
-            showMessages: {
-              success: true,
-            },
-          },
-          requestPassword: {
-            redirectDelay: 0,
-            showMessages: {
-              success: true,
-            },
-          },
-          resetPassword: {
-            redirectDelay: 0,
-            showMessages: {
-              success: true,
-            },
-          },
-          logout: {
-            redirectDelay: 0,
-          },
-        },
-     }), 
+       }), 
   ],
 });
 
@@ -181,24 +175,21 @@ const formSetting: any = {
    // ...
     
    NbAuthModule.forRoot({
-         strategies: {
-           email: {
-             service: NbPasswordAuthStrategy,
-             options: {
-              ...
-             },
+         strategies: [
+           NbPasswordAuthStrategy.setup({
+             name: 'email',
+           }),
+         ],
+         forms: {
+           login: formSetting,
+           register: formSetting,
+           requestPassword: formSetting,
+           resetPassword: formSetting,
+           logout: {
+             redirectDelay: 0,
            },
          },
-         forms: {
-          login: formSetting,
-          register: formSetting,
-          requestPassword: formSetting,
-          resetPassword: formSetting,
-          logout: {
-            redirectDelay: 0,
-          },
-        },
-     }), 
+       }), 
   ],
 });
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,7 @@ import {
   NbAuthModule,
   NbPasswordAuthStrategy,
   NbAuthJWTInterceptor,
+  NbDummyAuthStrategy,
 } from '@nebular/auth';
 
 import { NbSecurityModule, NbRoleProvider } from '@nebular/security';
@@ -166,46 +167,36 @@ const NB_TEST_COMPONENTS = [
           ],
         },
       },
-      strategies: {
-        //
-        // email: {
-        //   service: NbDummyAuthStrategy,
-        //   options: {
-        //     alwaysFail: true,
-        //     delay: 1000,
-        //   },
-        // },
-        email: {
-          service: NbPasswordAuthStrategy,
-          options: {
-            login: {
-              endpoint: 'http://localhost:4400/api/auth/login',
-            },
-            register: {
-              endpoint: 'http://localhost:4400/api/auth/register',
-            },
-            logout: {
-              endpoint: 'http://localhost:4400/api/auth/logout',
-              redirect: {
-                success: '/auth/login',
-                failure: '/auth/login',
-              },
-            },
-            requestPass: {
-              endpoint: 'http://localhost:4400/api/auth/request-pass',
-              redirect: {
-                success: '/auth/reset-password',
-              },
-            },
-            resetPass: {
-              endpoint: 'http://localhost:4400/api/auth/reset-pass',
-              redirect: {
-                success: '/auth/login',
-              },
+      strategies: [
+        NbDummyAuthStrategy.setup({
+          name: 'dummy',
+
+          alwaysFail: true,
+          delay: 1000,
+        }),
+
+        NbPasswordAuthStrategy.setup({
+          name: 'email',
+
+          baseEndpoint: 'http://localhost:4400/api/auth/',
+          logout: {
+            redirect: {
+              success: '/auth/login',
+              failure: '/auth/login',
             },
           },
-        },
-      },
+          requestPass: {
+            redirect: {
+              success: '/auth/reset-password',
+            },
+          },
+          resetPass: {
+            redirect: {
+              success: '/auth/login',
+            },
+          },
+        }),
+      ],
     }),
     NbSecurityModule.forRoot({
       accessControl: {

--- a/src/framework/auth/auth.options.ts
+++ b/src/framework/auth/auth.options.ts
@@ -1,13 +1,14 @@
 import { InjectionToken } from '@angular/core';
 import { NbAuthToken } from './services';
+import { NbAuthStrategy, NbAuthStrategyOptions } from './strategies';
+
+export type NbAuthStrategyClass = new (...params: any[]) => NbAuthStrategy;
+
+export type NbAuthStrategies  = [NbAuthStrategyClass, NbAuthStrategyOptions][];
 
 export interface NbAuthOptions {
   forms?: any;
-  strategies?: any;
-}
-
-export interface NbAuthStrategies {
-  [key: string]: any;
+  strategies?: NbAuthStrategies;
 }
 
 export interface NbAuthSocialLink {
@@ -20,7 +21,8 @@ export interface NbAuthSocialLink {
 
 const socialLinks: NbAuthSocialLink[] = [];
 
-export const defaultOptions: any = {
+export const defaultAuthOptions: any = {
+  strategies: [],
   forms: {
     login: {
       redirectDelay: 500, // delay before redirect after a successful login, while success message is shown to the user

--- a/src/framework/auth/services/auth.service.ts
+++ b/src/framework/auth/services/auth.service.ts
@@ -3,7 +3,7 @@
  * Copyright Akveo. All Rights Reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
-import { Inject, Injectable, Injector, Optional } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
 import { switchMap } from 'rxjs/operators/switchMap';
@@ -24,8 +24,7 @@ import { NbAuthToken } from './token/token';
 export class NbAuthService {
 
   constructor(protected tokenService: NbTokenService,
-              protected injector: Injector,
-              @Optional() @Inject(NB_AUTH_STRATEGIES) protected strategies = {}) {
+              @Inject(NB_AUTH_STRATEGIES) protected strategies) {
   }
 
   /**
@@ -169,10 +168,12 @@ export class NbAuthService {
   }
 
   private getStrategy(strategyName: string): NbAuthStrategy {
-    if (!this.strategies[strategyName]) {
-      throw new TypeError(`NbAuthStrategy '${strategyName}' is not registered`);
+    const found = this.strategies.find((strategy: NbAuthStrategy) => strategy.getName() === strategyName);
+
+    if (!found) {
+      throw new TypeError(`There is no Auth Strategy registered under '${strategyName}' name`);
     }
 
-    return this.injector.get(this.strategies[strategyName].service);
+    return found;
   }
 }

--- a/src/framework/auth/services/auth.spec.ts
+++ b/src/framework/auth/services/auth.spec.ts
@@ -7,10 +7,10 @@
 import { TestBed } from '@angular/core/testing';
 import { Injector } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
-import { NB_AUTH_OPTIONS, NB_AUTH_TOKEN_CLASS, NB_AUTH_USER_OPTIONS } from '../auth.options';
+import { NB_AUTH_OPTIONS, NB_AUTH_TOKEN_CLASS, NB_AUTH_USER_OPTIONS, NB_AUTH_STRATEGIES } from '../auth.options';
 import { NbAuthService } from './auth.service';
 import { NbDummyAuthStrategy } from '../strategies';
-import { nbAuthServiceFactory, nbOptionsFactory } from '../auth.module';
+import { nbStrategiesFactory, nbOptionsFactory } from '../auth.module';
 import { of as observableOf } from 'rxjs/observable/of';
 import { first } from 'rxjs/operators';
 import { NbAuthResult } from './auth-result';
@@ -75,26 +75,21 @@ describe('auth-service', () => {
                 redirectDelay: 3000,
               },
             },
-            strategies: {
-              dummy: {
-                service: NbDummyAuthStrategy,
-                options: {
-                  alwaysFail: true,
-                  delay: 1000,
-                },
-              },
-            },
+            strategies: [
+              NbDummyAuthStrategy.setup({
+                name: 'dummy',
+
+                alwaysFail: true,
+                delay: 1000,
+              }),
+            ],
           },
         },
         { provide: NB_AUTH_OPTIONS, useFactory: nbOptionsFactory, deps: [NB_AUTH_USER_OPTIONS] },
+        { provide: NB_AUTH_STRATEGIES, useFactory: nbStrategiesFactory, deps: [NB_AUTH_OPTIONS, Injector] },
         { provide: NbTokenStorage, useClass: NbTokenLocalStorage },
-
         NbTokenService,
-        {
-          provide: NbAuthService,
-          useFactory: nbAuthServiceFactory,
-          deps: [NB_AUTH_OPTIONS, NbTokenService, Injector],
-        },
+        NbAuthService,
         NbDummyAuthStrategy,
       ],
     });

--- a/src/framework/auth/strategies/auth-strategy-options.ts
+++ b/src/framework/auth/strategies/auth-strategy-options.ts
@@ -7,8 +7,8 @@ import { NbTokenClass } from '../services/';
 
 export class NbAuthStrategyOptions {
   name: string;
-  token: {
-    class: NbTokenClass;
+  token?: {
+    class?: NbTokenClass;
     [key: string]: any;
   };
 }

--- a/src/framework/auth/strategies/auth-strategy.ts
+++ b/src/framework/auth/strategies/auth-strategy.ts
@@ -1,7 +1,7 @@
 import { HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Rx';
 import { NbAuthResult } from '../services/auth-result';
-import { NbAuthStrategyOptions } from './strategy-options';
+import { NbAuthStrategyOptions } from './auth-strategy-options';
 import { deepExtend, getDeepFromObject } from '../helpers';
 
 export abstract class NbAuthStrategy {
@@ -17,6 +17,10 @@ export abstract class NbAuthStrategy {
 
   getOption(key: string): any {
     return getDeepFromObject(this.options, key, null);
+  }
+
+  getName(): string {
+    return this.getOption('name');
   }
 
   abstract authenticate(data?: any): Observable<NbAuthResult>;

--- a/src/framework/auth/strategies/dummy/dummy-strategy-options.ts
+++ b/src/framework/auth/strategies/dummy/dummy-strategy-options.ts
@@ -3,12 +3,12 @@
  * Copyright Akveo. All Rights Reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
-import { NbAuthStrategyOptions } from '../strategy-options';
+import { NbAuthStrategyOptions } from '../auth-strategy-options';
 import { NbAuthSimpleToken } from '../../services/';
 
 export class NbDummyAuthStrategyOptions extends NbAuthStrategyOptions {
-  name = 'dummy';
-  token = {
+  name: string;
+  token? = {
     class: NbAuthSimpleToken,
   };
   delay? = 1000;

--- a/src/framework/auth/strategies/dummy/dummy-strategy.ts
+++ b/src/framework/auth/strategies/dummy/dummy-strategy.ts
@@ -6,7 +6,7 @@ import { delay } from 'rxjs/operators/delay';
 
 import { NbAuthStrategy } from '../auth-strategy';
 import { NbAuthResult } from '../../services/auth-result';
-import { dummyStrategyOptions } from './dummy-strategy-options';
+import { NbDummyAuthStrategyOptions, dummyStrategyOptions } from './dummy-strategy-options';
 
 
 /**
@@ -31,6 +31,10 @@ import { dummyStrategyOptions } from './dummy-strategy-options';
 export class NbDummyAuthStrategy extends NbAuthStrategy {
 
   protected defaultOptions = dummyStrategyOptions;
+
+  static setup(options: NbDummyAuthStrategyOptions) {
+    return [NbDummyAuthStrategy, options];
+  }
 
   authenticate(data?: any): Observable<NbAuthResult> {
     return observableOf(this.createDummyResult(data))

--- a/src/framework/auth/strategies/index.ts
+++ b/src/framework/auth/strategies/index.ts
@@ -1,4 +1,6 @@
 export * from './auth-strategy';
+export * from './auth-strategy-options';
 export * from './dummy/dummy-strategy';
+export * from './dummy/dummy-strategy-options';
 export * from './password/password-strategy';
 export * from './password/password-strategy-options';

--- a/src/framework/auth/strategies/password/password-strategy-options.ts
+++ b/src/framework/auth/strategies/password/password-strategy-options.ts
@@ -5,7 +5,7 @@
  */
 
 import { NbAuthSimpleToken } from '../../services';
-import { NbAuthStrategyOptions } from '../strategy-options';
+import { NbAuthStrategyOptions } from '../auth-strategy-options';
 import { getDeepFromObject } from '../../helpers';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 
@@ -27,7 +27,7 @@ export interface NbPasswordStrategyResetOptions extends NbPasswordStrategyModule
 }
 
 export class NbPasswordAuthStrategyOptions extends NbAuthStrategyOptions {
-  name = 'email';
+  name: string;
   baseEndpoint? = '/api/auth/';
   login?: boolean | NbPasswordStrategyModule = {
     alwaysFail: false,
@@ -85,7 +85,7 @@ export class NbPasswordAuthStrategyOptions extends NbAuthStrategyOptions {
     defaultErrors: ['Something went wrong, please try again.'],
     defaultMessages: ['You have been successfully logged out.'],
   };
-  token = {
+  token? = {
     key: 'data.token',
     getter: (module: string, res: HttpResponse<Object>, options: NbPasswordAuthStrategyOptions) => getDeepFromObject(
       res.body,

--- a/src/framework/auth/strategies/password/password-strategy.ts
+++ b/src/framework/auth/strategies/password/password-strategy.ts
@@ -14,7 +14,7 @@ import { catchError } from 'rxjs/operators/catchError';
 
 import { NbAuthResult } from '../../services/auth-result';
 import { NbAuthStrategy } from '../auth-strategy';
-import { passwordStrategyOptions } from './password-strategy-options';
+import { NbPasswordAuthStrategyOptions, passwordStrategyOptions } from './password-strategy-options';
 
 /**
  * The most common authentication provider for email/password strategy.
@@ -133,6 +133,10 @@ import { passwordStrategyOptions } from './password-strategy-options';
 export class NbPasswordAuthStrategy extends NbAuthStrategy {
 
   protected defaultOptions = passwordStrategyOptions;
+
+  static setup(options: NbPasswordAuthStrategyOptions) {
+    return [NbPasswordAuthStrategy, options];
+  }
 
   constructor(protected http: HttpClient, private route: ActivatedRoute) {
     super();


### PR DESCRIPTION
Refactor strategies object to an array and pass strategy options through `setup` method.
Strategy name moved inside of options object.

BREAKING CHANGE:
Auth module options' `strategies` list changed from a key=>value object to an array.
So now instead of
```
...
strategies: {
  email: {
    service: NbEmailPassAuthProvider,
    config: { ... }
  }
}
```
we do this:

```
strategies: [
  NbPasswordAuthStrategy.setup({ name: 'email', ... }),
]
```
This way we can type-check the configuration object for each strategy specified.

### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
