### PR TITLE
feat(auth): add support for refresh tokens

### DIFF
--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -125,6 +125,21 @@ app.delete('/api/auth/logout', function (req, res) {
   });
 });
 
+app.post('/api/auth/refresh-token', function (req, res) {
+    var payload = {
+        id: users[0].id,
+        email: users[0].email,
+        role: 'user',
+    };
+    var token = jwt.encode(payload, cfg.jwtSecret);
+    return res.json({
+        data: {
+            message: 'Successfully refreshed token.',
+            token: token
+        }
+    });
+});
+
 app.listen(4400, function () {
   console.log('ngx-admin sample API is running on 4400');
 });

--- a/src/framework/auth/providers/abstract-auth.provider.ts
+++ b/src/framework/auth/providers/abstract-auth.provider.ts
@@ -27,6 +27,8 @@ export abstract class NbAbstractAuthProvider {
 
   abstract logout(): Observable<NbAuthResult>;
 
+  abstract refreshToken(): Observable<NbAuthResult>;
+
   protected createFailResponse(data?: any): HttpResponse<Object> {
     return new HttpResponse<Object>({ body: {}, status: 401 });
   }

--- a/src/framework/auth/providers/dummy-auth.provider.ts
+++ b/src/framework/auth/providers/dummy-auth.provider.ts
@@ -54,6 +54,13 @@ export class NbDummyAuthProvider extends NbAbstractAuthProvider {
       );
   }
 
+  refreshToken(data?: any): Observable<NbAuthResult> {
+    return observableOf(this.createDummyResult(data))
+      .pipe(
+        delay(this.getConfigValue('delay')),
+      );
+  }
+
   protected createDummyResult(data?: any): NbAuthResult {
     if (this.getConfigValue('alwaysFail')) {
       // TODO we dont call tokenService clear during logout in case result is not success

--- a/src/framework/auth/providers/email-pass-auth.options.ts
+++ b/src/framework/auth/providers/email-pass-auth.options.ts
@@ -31,6 +31,7 @@ export interface NgEmailPassAuthProviderConfig {
   requestPass?: boolean | NbEmailPassModuleConfig;
   resetPass?: boolean | NbEmailPassResetModuleConfig;
   logout?: boolean | NbEmailPassResetModuleConfig;
+  refreshToken?: boolean | NbEmailPassModuleConfig;
   token?: {
     key?: string;
     getter?: Function;

--- a/src/framework/auth/providers/email-pass-auth.spec.ts
+++ b/src/framework/auth/providers/email-pass-auth.spec.ts
@@ -250,6 +250,43 @@ describe('email-pass-auth-provider', () => {
         .flush(successResponse, { status: 401, statusText: 'Unauthorized' });
     });
 
+    it('refreshToken success', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(true);
+          expect(result.isFailure()).toBe(false);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual(successResponse.data.messages);
+          expect(result.getErrors()).toEqual([]); // no error message, response is success
+          expect(result.getRawToken()).toEqual(successResponse.data.token);
+          expect(result.getRedirect()).toEqual(null);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token').flush(successResponse);
+    });
+
+    it('refreshToken fail', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isSuccess()).toBe(false);
+          expect(result.isFailure()).toBe(true);
+          expect(result.getToken()).toBeUndefined(); // we don't have a token at this stage yet
+          expect(result.getMessages()).toEqual([]);
+          expect(result.getErrors()).toEqual(successResponse.data.errors); // no error message, response is success
+          expect(result.getRawToken()).toBeUndefined();
+          expect(result.getRedirect()).toEqual(null);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(successResponse, { status: 401, statusText: 'Unauthorized' });
+    });
+
   });
 
   describe('always fail', () => {
@@ -269,6 +306,9 @@ describe('email-pass-auth-provider', () => {
           alwaysFail: true,
         },
         resetPass: {
+          alwaysFail: true,
+        },
+        refreshToken: {
           alwaysFail: true,
         },
       });
@@ -344,6 +384,20 @@ describe('email-pass-auth-provider', () => {
         .flush(successResponse);
     });
 
+    it('refreshToken fail', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(true);
+          expect(result.isSuccess()).toBe(false);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(successResponse);
+    });
+
   });
 
   describe('custom endpoint', () => {
@@ -363,6 +417,9 @@ describe('email-pass-auth-provider', () => {
           endpoint: 'new',
         },
         resetPass: {
+          endpoint: 'new',
+        },
+        refreshToken: {
           endpoint: 'new',
         },
       });
@@ -426,6 +483,20 @@ describe('email-pass-auth-provider', () => {
 
     it('logout', (done: DoneFn) => {
       provider.logout()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(false);
+          expect(result.isSuccess()).toBe(true);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/new')
+        .flush(successResponse);
+    });
+
+    it('refreshToken', (done: DoneFn) => {
+      provider.refreshToken()
         .subscribe((result: NbAuthResult) => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
@@ -518,6 +589,20 @@ describe('email-pass-auth-provider', () => {
         .flush(successResponse);
     });
 
+    it('refreshToken', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(false);
+          expect(result.isSuccess()).toBe(true);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/custom/refresh-token')
+        .flush(successResponse);
+    });
+
   });
 
   describe('custom method', () => {
@@ -537,6 +622,9 @@ describe('email-pass-auth-provider', () => {
           method: 'get',
         },
         resetPass: {
+          method: 'get',
+        },
+        refreshToken: {
           method: 'get',
         },
       });
@@ -612,6 +700,20 @@ describe('email-pass-auth-provider', () => {
         .flush(successResponse);
     });
 
+    it('refreshToken', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(false);
+          expect(result.isSuccess()).toBe(true);
+
+          done();
+        });
+
+      httpMock.expectOne({ method: 'get' })
+        .flush(successResponse);
+    });
+
   });
 
   describe('custom redirect', () => {
@@ -637,6 +739,9 @@ describe('email-pass-auth-provider', () => {
           redirect,
         },
         resetPass: {
+          redirect,
+        },
+        refreshToken: {
           redirect,
         },
       });
@@ -772,6 +877,32 @@ describe('email-pass-auth-provider', () => {
         .flush(successResponse, { status: 401, statusText: 'Unauthorized' });
     });
 
+    it('refreshToken success', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.getRedirect()).toBe(redirect.success);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(successResponse);
+    });
+
+    it('refreshToken fail', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.getRedirect()).toBe(redirect.failure);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(successResponse, { status: 401, statusText: 'Unauthorized' });
+    });
+
   });
 
   describe('custom message', () => {
@@ -797,6 +928,9 @@ describe('email-pass-auth-provider', () => {
           ...messages,
         },
         resetPass: {
+          ...messages,
+        },
+        refreshToken: {
           ...messages,
         },
       });
@@ -932,6 +1066,32 @@ describe('email-pass-auth-provider', () => {
         .flush(noMessageResponse, { status: 401, statusText: 'Unauthorized' });
     });
 
+    it('refreshToken success', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.getMessages()).toEqual(messages.defaultMessages);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(noMessageResponse);
+    });
+
+    it('refreshToken fail', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.getErrors()).toEqual(messages.defaultErrors);
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(noMessageResponse, { status: 401, statusText: 'Unauthorized' });
+    });
+
   });
 
   describe('custom token key', () => {
@@ -974,6 +1134,21 @@ describe('email-pass-auth-provider', () => {
         .flush(customResponse);
     });
 
+    it('refreshToken', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(false);
+          expect(result.isSuccess()).toBe(true);
+          expect(result.getRawToken()).toBe('token');
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(customResponse);
+    });
+
   });
 
   describe('custom token extractor', () => {
@@ -1013,6 +1188,21 @@ describe('email-pass-auth-provider', () => {
         });
 
       httpMock.expectOne('/api/auth/register')
+        .flush(customResponse);
+    });
+
+    it('refreshToken', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(false);
+          expect(result.isSuccess()).toBe(true);
+          expect(result.getRawToken()).toBe('token');
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
         .flush(customResponse);
     });
 
@@ -1094,6 +1284,36 @@ describe('email-pass-auth-provider', () => {
         .flush(customResponse, { status: 401, statusText: 'Unauthorized' });
     });
 
+    it('refreshToken success', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(false);
+          expect(result.isSuccess()).toBe(true);
+          expect(result.getMessages()[0]).toBe('Success message');
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(customResponse);
+    });
+
+    it('refreshToken fail', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(true);
+          expect(result.isSuccess()).toBe(false);
+          expect(result.getErrors()[0]).toBe('Error message');
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(customResponse, { status: 401, statusText: 'Unauthorized' });
+    });
+
   });
 
   describe('custom message extractor', () => {
@@ -1169,6 +1389,36 @@ describe('email-pass-auth-provider', () => {
         });
 
       httpMock.expectOne('/api/auth/register')
+        .flush(customResponse, { status: 401, statusText: 'Unauthorized' });
+    });
+
+    it('refreshToken success', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(false);
+          expect(result.isSuccess()).toBe(true);
+          expect(result.getMessages()[0]).toBe('Success message');
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
+        .flush(customResponse);
+    });
+
+    it('refreshToken fail', (done: DoneFn) => {
+      provider.refreshToken()
+        .subscribe((result: NbAuthResult) => {
+          expect(result).toBeTruthy();
+          expect(result.isFailure()).toBe(true);
+          expect(result.isSuccess()).toBe(false);
+          expect(result.getErrors()[0]).toBe('Error message');
+
+          done();
+        });
+
+      httpMock.expectOne('/api/auth/refresh-token')
         .flush(customResponse, { status: 401, statusText: 'Unauthorized' });
     });
 

--- a/src/framework/auth/services/auth.service.ts
+++ b/src/framework/auth/services/auth.service.ts
@@ -154,6 +154,26 @@ export class NbAuthService {
   }
 
   /**
+   * Sends a refresh token request
+   * Stores received token in the token storage
+   *
+   * Example:
+   * authenticate('email', {email: 'email@example.com', password: 'test'})
+   *
+   * @param {string} provider
+   * @param data
+   * @returns {Observable<NbAuthResult>}
+   */
+  refreshToken(provider: string, data?: any): Observable<NbAuthResult> {
+    return this.getProvider(provider).refreshToken()
+      .pipe(
+        switchMap((result: NbAuthResult) => {
+          return this.processResultToken(result);
+        }),
+      );
+  }
+
+  /**
    * Gets the selected provider
    *
    * Example:

--- a/src/framework/auth/services/auth.service.ts
+++ b/src/framework/auth/services/auth.service.ts
@@ -153,6 +153,22 @@ export class NbAuthService {
     return this.getProvider(provider).resetPassword(data);
   }
 
+  /**
+   * Gets the selected provider
+   *
+   * Example:
+   * getProvider('email')
+   *
+   * @param {string} provider
+   * @returns {NbAbstractAuthProvider}
+   */
+  protected getProvider(provider: string): NbAbstractAuthProvider {
+    if (!this.providers[provider]) {
+      throw new TypeError(`Nb auth provider '${provider}' is not registered`);
+    }
+    return this.injector.get(this.providers[provider].service);
+  }
+
   private processResultToken(result: NbAuthResult) {
     if (result.isSuccess() && result.getRawToken()) {
       return this.tokenService.setRaw(result.getRawToken())
@@ -166,13 +182,5 @@ export class NbAuthService {
     }
 
     return observableOf(result);
-  }
-
-  private getProvider(provider: string): NbAbstractAuthProvider {
-    if (!this.providers[provider]) {
-      throw new TypeError(`Nb auth provider '${provider}' is not registered`);
-    }
-
-    return this.injector.get(this.providers[provider].service);
   }
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Added a way to refresh tokens inside the AuthService. This is not yet hooked anywhere, but it could be hooked inside an interceptor, as I've seen mentionned in #260. Typically, I think the refresh token would be stored in a HttpOnly cookie. This also addresses #362.

```
this.authService.refreshToken('email').subscribe((result: NbAuthResult) => {
  //Do something
});
```

I have also fixed #389, which involved changing `private getProvider` to `protected getProvider`.

Please let me know if I need to change anything!
