### PR TITLE
Update sidebar.component.ts

### DIFF
--- a/src/framework/theme/components/sidebar/sidebar.component.ts
+++ b/src/framework/theme/components/sidebar/sidebar.component.ts
@@ -288,6 +288,13 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Get current state of sidebar
+   */
+  getState() {
+    return this.stateValue;
+  }
+
+  /**
    * Toggles sidebar state (expanded|collapsed|compacted)
    * @param {boolean} compact If true, then sidebar state will be changed between expanded & compacted,
    * otherwise - between expanded & collapsed. False by default.


### PR DESCRIPTION
Add getState method so we check if the sidebar is already expanded or not.
There are cases that we need to show data in sidedar when clicking on some item. If the user press on another item the sidebar will collapse.  

### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
