### PR TITLE
fix(theme): add new variable for focused outline buttons

### DIFF
--- a/src/framework/theme/styles/global/bootstrap/_default-buttons.scss
+++ b/src/framework/theme/styles/global/bootstrap/_default-buttons.scss
@@ -113,7 +113,7 @@
 @mixin btn-outline-focus($focus) {
   &:focus,
   &.focus {
-    color: nb-theme(btn-outline-hover-fg);
+    color: nb-theme(btn-outline-focus-fg);
     border-color: $focus;
     box-shadow: none;
   }

--- a/src/framework/theme/styles/themes/_cosmic.scss
+++ b/src/framework/theme/styles/themes/_cosmic.scss
@@ -94,6 +94,7 @@ $theme: (
   btn-secondary-border: color-primary,
   btn-outline-fg: color-fg-heading,
   btn-outline-hover-fg: color-fg-heading,
+  btn-outline-focus-fg: color-fg-heading,
   btn-group-bg: #373273,
   btn-group-separator: #312c66,
 

--- a/src/framework/theme/styles/themes/_default.scss
+++ b/src/framework/theme/styles/themes/_default.scss
@@ -342,6 +342,7 @@ $theme: (
 
   btn-outline-fg: color-fg-heading,
   btn-outline-hover-fg: #ffffff,
+  btn-outline-focus-fg: color-fg-heading,
 
   btn-group-bg: layout-bg,
   btn-group-fg: color-fg-heading,


### PR DESCRIPTION
Fix color for focused outline buttons, add new variable btn-outline-focus-fg

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
