### PR TITLE
Refresh token requests fully managed by NbAuthService & NbAuthJWTInterceptor

### DIFF
--- a/docs/app/app.module.ts
+++ b/docs/app/app.module.ts
@@ -40,7 +40,7 @@ const docs = require('../output.json');
     NbCheckboxModule,
     NbProgressBarModule,
     NbMenuModule.forRoot(),
-    NbThemeModule.forRoot({ name: '' }),
+    NbThemeModule.forRoot({ name: 'default' }),
     NgdThemeModule.forRoot(),
     NbSidebarModule.forRoot(),
     RouterModule.forRoot(routes, { useHash: false }),

--- a/src/framework/auth/services/auth.spec.ts
+++ b/src/framework/auth/services/auth.spec.ts
@@ -24,12 +24,13 @@ describe('auth-service', () => {
   let tokenService: NbTokenService;
   let dummyAuthStrategy: NbDummyAuthStrategy;
   const testTokenValue = 'test-token';
+  const ownerStrategyName = 'strategy';
 
   const resp401 = new HttpResponse<Object>({body: {}, status: 401});
   const resp200 = new HttpResponse<Object>({body: {}, status: 200});
 
-  const testToken = nbAuthCreateToken(NbAuthSimpleToken, testTokenValue);
-  const emptyToken = nbAuthCreateToken(NbAuthSimpleToken, null);
+  const testToken = nbAuthCreateToken(NbAuthSimpleToken, testTokenValue, ownerStrategyName);
+  const emptyToken = nbAuthCreateToken(NbAuthSimpleToken, null, ownerStrategyName);
 
   const failResult = new NbAuthResult(false,
     resp401,

--- a/src/framework/auth/services/auth.spec.ts
+++ b/src/framework/auth/services/auth.spec.ts
@@ -26,6 +26,7 @@ describe('auth-service', () => {
   const testTokenValue = 'test-token';
   const ownerStrategyName = 'strategy';
 
+
   const resp401 = new HttpResponse<Object>({body: {}, status: 401});
   const resp200 = new HttpResponse<Object>({body: {}, status: 200});
 

--- a/src/framework/auth/services/token/token-parceler.spec.ts
+++ b/src/framework/auth/services/token/token-parceler.spec.ts
@@ -13,13 +13,15 @@ import { NB_AUTH_TOKENS } from '../../auth.options';
 describe('token-parceler', () => {
 
   let tokenParceler: NbAuthTokenParceler;
-  const simpleToken = nbAuthCreateToken(NbAuthSimpleToken, 'test value');
-  const wrappedSimple = `{"name":"${NbAuthSimpleToken.NAME}","value":"${simpleToken.getValue()}"}`;
+  const simpleToken = nbAuthCreateToken(NbAuthSimpleToken, 'test value', 'strategy');
   // tslint:disable-next-line
-  const jwtToken = nbAuthCreateToken(NbAuthJWTToken, 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjI1MTczMTQwNjYxNzUsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0=.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773');
-  const wrappedJWT = `{"name":"${NbAuthJWTToken.NAME}","value":"${jwtToken.getValue()}"}`;
-
-  const wrappedNonExisting = `{"name":"non-existing","value":"${simpleToken.getValue()}"}`;
+  const wrappedSimple = `{"name":"${NbAuthSimpleToken.NAME}","ownerStrategyName":"${simpleToken.getOwnerStrategyName()}","value":"${simpleToken.getValue()}"}`;
+  // tslint:disable-next-line
+  const jwtToken = nbAuthCreateToken(NbAuthJWTToken, 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjI1MTczMTQwNjYxNzUsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0=.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773', 'strategy');
+  // tslint:disable-next-line
+  const wrappedJWT = `{"name":"${NbAuthJWTToken.NAME}","ownerStrategyName":"${jwtToken.getOwnerStrategyName()}","value":"${jwtToken.getValue()}"}`;
+  // tslint:disable-next-line
+  const wrappedNonExisting = `{"name":"non-existing","value":"${simpleToken.getValue()}","ownerStrategyName":"${simpleToken.getOwnerStrategyName()}"}`;
   const wrappedInvalid = `{"name":"non-existing"`;
 
   describe('default configuration', () => {

--- a/src/framework/auth/services/token/token-parceler.ts
+++ b/src/framework/auth/services/token/token-parceler.ts
@@ -5,6 +5,7 @@ import { NB_AUTH_TOKENS } from '../../auth.options';
 
 export interface NbTokenPack {
   name: string,
+  ownerStrategyName: string,
   value: string,
 }
 
@@ -23,6 +24,7 @@ export class NbAuthTokenParceler {
   wrap(token: NbAuthToken): string {
     return JSON.stringify({
       name: token.getName(),
+      ownerStrategyName: token.getOwnerStrategyName(),
       value: token.toString(),
     });
   }
@@ -30,14 +32,15 @@ export class NbAuthTokenParceler {
   unwrap(value: string): NbAuthToken {
     let tokenClass: NbAuthTokenClass = this.fallbackClass;
     let tokenValue = '';
-
+    let tokenOwnerStrategyName = '';
     const tokenPack: NbTokenPack = this.parseTokenPack(value);
     if (tokenPack) {
       tokenClass = this.getClassByName(tokenPack.name) || this.fallbackClass;
       tokenValue = tokenPack.value;
+      tokenOwnerStrategyName = tokenPack.ownerStrategyName;
     }
 
-    return nbAuthCreateToken(tokenClass, tokenValue);
+    return nbAuthCreateToken(tokenClass, tokenValue, tokenOwnerStrategyName);
   }
 
   // TODO: this could be moved to a separate token registry

--- a/src/framework/auth/services/token/token-service.spec.ts
+++ b/src/framework/auth/services/token/token-service.spec.ts
@@ -15,13 +15,14 @@ import { NB_AUTH_FALLBACK_TOKEN, NbAuthTokenParceler } from './token-parceler';
 import { NB_AUTH_TOKENS } from '../../auth.options';
 
 const noop = () => {};
+const ownerStrategyName = 'strategy';
 
 describe('token-service', () => {
 
   let tokenService: NbTokenService;
   let tokenStorage: NbTokenLocalStorage;
-  const simpleToken = nbAuthCreateToken(NbAuthSimpleToken, 'test value');
-  const emptyToken = nbAuthCreateToken(NbAuthSimpleToken, '');
+  const simpleToken = nbAuthCreateToken(NbAuthSimpleToken, 'test value', ownerStrategyName);
+  const emptyToken = nbAuthCreateToken(NbAuthSimpleToken, '', ownerStrategyName);
   const testTokenKey = 'auth_app_token';
 
   beforeEach(() => {

--- a/src/framework/auth/services/token/token-storage.spec.ts
+++ b/src/framework/auth/services/token/token-storage.spec.ts
@@ -18,6 +18,7 @@ describe('token-storage', () => {
   let tokenParceler: NbAuthTokenParceler;
   const testTokenKey = 'auth_app_token';
   const testTokenValue = 'test-token';
+  const ownerStrategyName = 'strategy';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -44,7 +45,7 @@ describe('token-storage', () => {
 
 
   it('set test token', () => {
-    const token = nbAuthCreateToken(NbAuthSimpleToken, testTokenValue);
+    const token = nbAuthCreateToken(NbAuthSimpleToken, testTokenValue, ownerStrategyName);
 
     tokenStorage.set(token);
     expect(localStorage.getItem(testTokenKey)).toEqual(tokenParceler.wrap(token));
@@ -53,11 +54,11 @@ describe('token-storage', () => {
   it('setter set invalid token to localStorage as empty string', () => {
     let token;
 
-    token = nbAuthCreateToken(NbAuthSimpleToken, null);
+    token = nbAuthCreateToken(NbAuthSimpleToken, null, ownerStrategyName);
     tokenStorage.set(token);
     expect(localStorage.getItem(testTokenKey)).toEqual(tokenParceler.wrap(token));
 
-    token = nbAuthCreateToken(NbAuthSimpleToken, undefined);
+    token = nbAuthCreateToken(NbAuthSimpleToken, undefined, ownerStrategyName);
     tokenStorage.set(token);
     expect(localStorage.getItem(testTokenKey)).toEqual(tokenParceler.wrap(token));
   });
@@ -69,14 +70,14 @@ describe('token-storage', () => {
   });
 
   it('should return correct value', () => {
-    const token = nbAuthCreateToken(NbAuthSimpleToken, 'test');
+    const token = nbAuthCreateToken(NbAuthSimpleToken, 'test', ownerStrategyName);
     localStorage.setItem(testTokenKey, tokenParceler.wrap(token));
 
     expect(tokenStorage.get().getValue()).toEqual(token.getValue());
   });
 
   it('clear remove token', () => {
-    const token = nbAuthCreateToken(NbAuthSimpleToken, 'test');
+    const token = nbAuthCreateToken(NbAuthSimpleToken, 'test', ownerStrategyName);
     localStorage.setItem(testTokenKey, tokenParceler.wrap(token));
 
     tokenStorage.clear();
@@ -85,7 +86,7 @@ describe('token-storage', () => {
   });
 
   it('clear remove token only', () => {
-    const token = nbAuthCreateToken(NbAuthSimpleToken, 'test');
+    const token = nbAuthCreateToken(NbAuthSimpleToken, 'test', ownerStrategyName);
     localStorage.setItem(testTokenKey, tokenParceler.wrap(token));
     localStorage.setItem(testTokenKey + '2', tokenParceler.wrap(token));
 

--- a/src/framework/auth/services/token/token.spec.ts
+++ b/src/framework/auth/services/token/token.spec.ts
@@ -10,16 +10,16 @@ import { NbAuthOAuth2Token, NbAuthJWTToken, NbAuthSimpleToken } from './token';
 describe('auth token', () => {
   describe('NbAuthJWTToken', () => {
     // tslint:disable
-    const simpleToken = new NbAuthSimpleToken('token');
-    const validJWTToken = new NbAuthJWTToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjI1MTczMTQwNjYxNzUsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0=.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773');
-    const emptyJWTToken = new NbAuthJWTToken('..');
-    const invalidBase64JWTToken = new NbAuthJWTToken('h%2BHY.h%2BHY.h%2BHY');
+    const simpleToken = new NbAuthSimpleToken('token','strategy');
+    const validJWTToken = new NbAuthJWTToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjI1MTczMTQwNjYxNzUsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0=.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773', 'strategy');
+    const emptyJWTToken = new NbAuthJWTToken('..', 'strategy');
+    const invalidBase64JWTToken = new NbAuthJWTToken('h%2BHY.h%2BHY.h%2BHY','strategy');
 
-    const invalidJWTToken = new NbAuthJWTToken('.');
+    const invalidJWTToken = new NbAuthJWTToken('.','strategy');
 
-    const noExpJWTToken = new NbAuthJWTToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJuYW1lIjoiQ2hyaXMgU2V2aWxsZWphIiwiYWRtaW4iOnRydWV9.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773');
+    const noExpJWTToken = new NbAuthJWTToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJuYW1lIjoiQ2hyaXMgU2V2aWxsZWphIiwiYWRtaW4iOnRydWV9.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773','strategy');
 
-    const expiredJWTToken = new NbAuthJWTToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjEzMDA4MTkzODAsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773');
+    const expiredJWTToken = new NbAuthJWTToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjEzMDA4MTkzODAsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f75773','strategy');
     // tslint:enable
 
     it('getPayload success', () => {
@@ -71,7 +71,7 @@ describe('auth token', () => {
 
     it('isValid fail', () => {
       // without token
-      expect(new NbAuthJWTToken('').isValid()).toBeFalsy();
+      expect(new NbAuthJWTToken('', 'strategy').isValid()).toBeFalsy();
 
       // expired date
       expect(expiredJWTToken.isValid()).toBeFalsy();
@@ -123,14 +123,14 @@ describe('auth token', () => {
       example_parameter: 'example_value',
     };
 
-    const validToken = new NbAuthOAuth2Token(token);
-    const emptyToken = new NbAuthOAuth2Token({});
+    const validToken = new NbAuthOAuth2Token(token, 'strategy');
+    const emptyToken = new NbAuthOAuth2Token({}, 'strategy');
 
     const noExpToken = new NbAuthOAuth2Token({
       access_token: '2YotnFZFEjr1zCsicMWpAA',
       refresh_token: 'tGzv3JOkF0XG5Qx2TlKWIA',
       example_parameter: 'example_value',
-    });
+    }, 'strategy');
 
     it('getPayload success', () => {
       expect(validToken.getPayload()).toEqual(token);

--- a/src/framework/auth/strategies/auth-strategy.ts
+++ b/src/framework/auth/strategies/auth-strategy.ts
@@ -21,7 +21,7 @@ export abstract class NbAuthStrategy {
   }
 
   createToken(value: any): NbAuthToken {
-    return nbAuthCreateToken(this.getOption('token.class'), value);
+    return nbAuthCreateToken(this.getOption('token.class'), value, this.getName());
   }
 
   getName(): string {

--- a/src/framework/auth/strategies/oauth2/oauth2-strategy.spec.ts
+++ b/src/framework/auth/strategies/oauth2/oauth2-strategy.spec.ts
@@ -43,7 +43,7 @@ describe('oauth2-auth-strategy', () => {
     error_uri: 'some',
   };
 
-  const successToken = nbAuthCreateToken(NbAuthOAuth2Token, tokenSuccessResponse) as NbAuthOAuth2Token;
+  const successToken = nbAuthCreateToken(NbAuthOAuth2Token, tokenSuccessResponse, 'strategy') as NbAuthOAuth2Token;
 
 
   beforeEach(() => {
@@ -78,6 +78,7 @@ describe('oauth2-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         baseEndpoint: 'http://example.com/',
         clientId: 'clientId',
         clientSecret: 'clientSecret',
@@ -104,7 +105,8 @@ describe('oauth2-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
           expect(result.isFailure()).toBe(false);
-          expect(result.getToken()).toEqual(successToken);
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           expect(result.getMessages()).toEqual(successMessages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
           expect(result.getRedirect()).toEqual('/');
@@ -166,7 +168,8 @@ describe('oauth2-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
           expect(result.isFailure()).toBe(false);
-          expect(result.getToken()).toEqual(successToken);
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           expect(result.getMessages()).toEqual(successMessages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
           expect(result.getRedirect()).toEqual('/');
@@ -205,6 +208,7 @@ describe('oauth2-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         baseEndpoint: 'http://example.com/',
         clientId: 'clientId',
         clientSecret: 'clientSecret',
@@ -236,7 +240,8 @@ describe('oauth2-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
           expect(result.isFailure()).toBe(false);
-          expect(result.getToken()).toEqual(nbAuthCreateToken(NbAuthOAuth2Token, token));
+          // tslint:disable-next-line
+          expect(result.getToken().getValue()).toEqual(nbAuthCreateToken(NbAuthOAuth2Token, token, 'strategy').getValue());
           expect(result.getMessages()).toEqual(successMessages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
           expect(result.getRedirect()).toEqual('/');
@@ -266,6 +271,7 @@ describe('oauth2-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         baseEndpoint: 'http://example.com/',
         clientId: 'clientId',
         clientSecret: 'clientSecret',
@@ -317,7 +323,8 @@ describe('oauth2-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
           expect(result.isFailure()).toBe(false);
-          expect(result.getToken()).toEqual(successToken);
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           expect(result.getMessages()).toEqual(successMessages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
           expect(result.getRedirect()).toEqual('/success');
@@ -341,7 +348,8 @@ describe('oauth2-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
           expect(result.isFailure()).toBe(false);
-          expect(result.getToken()).toEqual(successToken);
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           expect(result.getMessages()).toEqual(successMessages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
           expect(result.getRedirect()).toEqual('/success');
@@ -376,7 +384,8 @@ describe('oauth2-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
           expect(result.isFailure()).toBe(false);
-          expect(result.getToken()).toEqual(successToken);
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           expect(result.getMessages()).toEqual(successMessages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
           expect(result.getRedirect()).toEqual('/success');
@@ -417,6 +426,7 @@ describe('oauth2-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         baseEndpoint: 'http://example.com/',
         clientId: 'clientId',
         clientSecret: 'clientSecret',
@@ -436,7 +446,8 @@ describe('oauth2-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
           expect(result.isFailure()).toBe(false);
-          expect(result.getToken()).toEqual(successToken);
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           expect(result.getMessages()).toEqual(successMessages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
           expect(result.getRedirect()).toEqual('/');

--- a/src/framework/auth/strategies/password/password-strategy.spec.ts
+++ b/src/framework/auth/strategies/password/password-strategy.spec.ts
@@ -26,7 +26,7 @@ describe('password-auth-strategy', () => {
     },
   };
 
-  const successToken = nbAuthCreateToken(NbAuthSimpleToken, 'token');
+  const successToken = nbAuthCreateToken(NbAuthSimpleToken, 'token', 'strategy');
 
   const noMessageResponse: any = {
     data: {
@@ -55,7 +55,7 @@ describe('password-auth-strategy', () => {
       strategy = _strategy;
       httpMock = _httpMock;
 
-      strategy.setOptions({});
+      strategy.setOptions({name: 'strategy'});
     },
   )));
 
@@ -66,7 +66,7 @@ describe('password-auth-strategy', () => {
   describe('out of the box', () => {
 
     beforeEach(() => {
-      strategy.setOptions({});
+      strategy.setOptions({name: 'strategy'});
     });
 
     it('authenticate success', (done: DoneFn) => {
@@ -77,7 +77,8 @@ describe('password-auth-strategy', () => {
           expect(result.isFailure()).toBe(false);
           expect(result.getMessages()).toEqual(successResponse.data.messages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
-          expect(result.getToken()).toEqual(successToken);
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           expect(result.getRedirect()).toEqual('/');
 
           done();
@@ -113,7 +114,8 @@ describe('password-auth-strategy', () => {
           expect(result.isFailure()).toBe(false);
           expect(result.getMessages()).toEqual(successResponse.data.messages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
-          expect(result.getToken()).toEqual(successToken);
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           expect(result.getRedirect()).toEqual('/');
 
           done();
@@ -250,7 +252,8 @@ describe('password-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isSuccess()).toBe(true);
           expect(result.isFailure()).toBe(false);
-          expect(result.getToken()).toEqual(successToken);
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           expect(result.getMessages()).toEqual(successResponse.data.messages);
           expect(result.getErrors()).toEqual([]); // no error message, response is success
           expect(result.getRedirect()).toEqual(null);
@@ -285,6 +288,7 @@ describe('password-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         login: {
           alwaysFail: true,
         },
@@ -396,6 +400,7 @@ describe('password-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         login: {
           endpoint: 'new',
         },
@@ -507,6 +512,7 @@ describe('password-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         baseEndpoint: '/api/auth/custom/',
       });
     });
@@ -601,6 +607,7 @@ describe('password-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         login: {
           method: 'get',
         },
@@ -718,6 +725,7 @@ describe('password-auth-strategy', () => {
     beforeEach(() => {
 
       strategy.setOptions({
+        name: 'strategy',
         login: {
           redirect,
         },
@@ -907,6 +915,7 @@ describe('password-auth-strategy', () => {
     beforeEach(() => {
 
       strategy.setOptions({
+        name: 'strategy',
         login: {
           ...messages,
         },
@@ -1090,6 +1099,7 @@ describe('password-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         token: {
           key: 'token',
         },
@@ -1102,8 +1112,8 @@ describe('password-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
           expect(result.isSuccess()).toBe(true);
-          expect(result.getToken()).toEqual(successToken);
-
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           done();
         });
 
@@ -1117,8 +1127,8 @@ describe('password-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
           expect(result.isSuccess()).toBe(true);
-          expect(result.getToken()).toEqual(successToken);
-
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           done();
         });
 
@@ -1132,8 +1142,8 @@ describe('password-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
           expect(result.isSuccess()).toBe(true);
-          expect(result.getToken()).toEqual(successToken);
-
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           done();
         });
 
@@ -1147,6 +1157,7 @@ describe('password-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         token: {
           getter: (module: string, res: HttpResponse<Object>) => res.body['token'],
         },
@@ -1159,8 +1170,8 @@ describe('password-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
           expect(result.isSuccess()).toBe(true);
-          expect(result.getToken()).toEqual(successToken);
-
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           done();
         });
 
@@ -1174,8 +1185,8 @@ describe('password-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
           expect(result.isSuccess()).toBe(true);
-          expect(result.getToken()).toEqual(successToken);
-
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           done();
         });
 
@@ -1189,8 +1200,8 @@ describe('password-auth-strategy', () => {
           expect(result).toBeTruthy();
           expect(result.isFailure()).toBe(false);
           expect(result.isSuccess()).toBe(true);
-          expect(result.getToken()).toEqual(successToken);
-
+          expect(result.getToken().getValue()).toEqual(successToken.getValue());
+          expect(result.getToken().getOwnerStrategyName()).toEqual(successToken.getOwnerStrategyName());
           done();
         });
 
@@ -1204,6 +1215,7 @@ describe('password-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         token: {
           key: 'token',
         },
@@ -1312,6 +1324,7 @@ describe('password-auth-strategy', () => {
 
     beforeEach(() => {
       strategy.setOptions({
+        name: 'strategy',
         token: {
           key: 'token',
         },
@@ -1438,6 +1451,7 @@ describe('password-auth-strategy', () => {
     it('authenticate does not fail even when no token', (done: DoneFn) => {
 
       strategy.setOptions({
+        name: 'strategy',
         login: {
           failWhenNoToken: false,
         },
@@ -1478,6 +1492,7 @@ describe('password-auth-strategy', () => {
     it('register does not fail even when no token', (done: DoneFn) => {
 
       strategy.setOptions({
+        name: 'strategy',
         register: {
           failWhenNoToken: false,
         },
@@ -1518,6 +1533,7 @@ describe('password-auth-strategy', () => {
     it('refreshToken does not fail even when no token', (done: DoneFn) => {
 
       strategy.setOptions({
+        name: 'strategy',
         refreshToken: {
           failWhenNoToken: false,
         },

--- a/src/framework/theme/components/button/button.component.scss
+++ b/src/framework/theme/components/button/button.component.scss
@@ -14,7 +14,6 @@
   -moz-appearance: none;
   text-align: center;
   text-decoration: none;
-  margin: 0;
   display: inline-block;
   white-space: nowrap;
   vertical-align: middle;

--- a/src/playground/accordion/accordion-toggle.component.html
+++ b/src/playground/accordion/accordion-toggle.component.html
@@ -1,6 +1,6 @@
 <nb-card>
   <nb-card-body>
-    <button class="btn btn-primary" (click)="toggle()">Toggle First Item</button>
+    <button nbButton (click)="toggle()">Toggle First Item</button>
   </nb-card-body>
 </nb-card>
 

--- a/src/playground/menu/menu-test.component.ts
+++ b/src/playground/menu/menu-test.component.ts
@@ -92,16 +92,16 @@ export class NbMenuItem4Component { }
           <nb-card-body>
             <nb-menu id="menu-first" tag="firstMenu" [items]="menuItems" [autoCollapse]="true"></nb-menu>
             <router-outlet></router-outlet>
-            <button class="btn btn-primary" id="addBtn" (click)="addMenuItem()">Add</button>
-            <button class="btn btn-primary" id="homeBtn" (click)="navigateHome()">Home</button>
+            <button nbButton id="addBtn" (click)="addMenuItem()">Add</button>
+            <button nbButton id="homeBtn" (click)="navigateHome()">Home</button>
           </nb-card-body>
         </nb-card>
         <nb-card size="xxlarge">
           <nb-card-body>
             <nb-menu id="menu-second" tag="SecondMenu" [items]="menuItems1"></nb-menu>
             <router-outlet></router-outlet>
-            <button class="btn btn-primary" id="addBtn" (click)="addMenuItem()">Add</button>
-            <button class="btn btn-primary" id="homeBtn" (click)="navigateHome()">Home</button>
+            <button nbButton id="addBtn" (click)="addMenuItem()">Add</button>
+            <button nbButton id="homeBtn" (click)="navigateHome()">Home</button>
           </nb-card-body>
         </nb-card>
         <nb-card size="xxlarge">

--- a/src/playground/oauth2-password/oauth2-password-login.component.ts
+++ b/src/playground/oauth2-password/oauth2-password-login.component.ts
@@ -27,7 +27,7 @@ import { getDeepFromObject } from '../../framework/auth/helpers';
             <p>Current User Access Token: {{ token.getValue() | json }}</p>
             <p>Current User Access Token Payload : {{getClaims(token.getValue()) | json}}</p>
             <p>Current User Refresh Token: {{ token.getRefreshToken() | json }}</p>
-            <button class="btn btn-warning" *ngIf="token" (click)="logout()">Sign Out</button>
+            <button nbButton status="warning" *ngIf="token" (click)="logout()">Sign Out</button>
           </nb-card-body>
           <nb-card-body *ngIf="! token"><p>No User Authenticated</p></nb-card-body>
         </nb-card>
@@ -71,8 +71,8 @@ import { getDeepFromObject } from '../../framework/auth/helpers';
                     {{ getConfigValue('forms.validation.password.maxLength') }} characters
                   </small>
                 </div>
-                <button [disabled]="submitted || !form.valid" class="btn btn-block btn-hero-success"
-                        [class.btn-pulse]="submitted"> Sign In
+                <button nbButton status="success" hero
+                        [disabled]="submitted || !form.valid" [class.btn-pulse]="submitted"> Sign In
                 </button>
               </form>
             </nb-auth-block>

--- a/src/playground/oauth2/oauth2-login.component.ts
+++ b/src/playground/oauth2/oauth2-login.component.ts
@@ -18,8 +18,8 @@ import { takeWhile } from 'rxjs/operators';
             <p>Current User Authenticated: {{ !!token }}</p>
             <p>Current User Token: {{ token|json }}</p>
 
-            <button class="btn btn-success" *ngIf="!token" (click)="login()">Sign In with Google</button>
-            <button class="btn btn-warning" *ngIf="token" (click)="logout()">Sign Out</button>
+            <button nbButton status="success" *ngIf="!token" (click)="login()">Sign In with Google</button>
+            <button nbButton status="warning" *ngIf="token" (click)="logout()">Sign Out</button>
           </nb-card-body>
         </nb-card>
       </nb-layout-column>

--- a/src/playground/playground.module.ts
+++ b/src/playground/playground.module.ts
@@ -29,6 +29,7 @@ import {
   NbSpinnerModule,
   NbStepperModule,
   NbAccordionModule,
+  NbButtonModule,
 } from '@nebular/theme';
 
 import { NbPlaygroundRoutingModule } from './playground-routing.module';
@@ -154,7 +155,6 @@ import { NbAccordionMultiComponent } from './accordion/accordion-multi.component
 import { NbLayoutSidebarSubheaderComponent } from './layout/layout-sidebar-subheader.component';
 import { NbLayoutSubheaderComponent } from './layout/layout-subheader.component';
 import { NbButtonShowcaseComponent } from './button/button-showcase.component';
-import { NbButtonModule } from '@nebular/theme/components/button/button.module';
 import { NbButtonColorsComponent } from './button/button-colors.component';
 import { NbButtonShapesComponent } from './button/button-shapes.component';
 import { NbButtonHeroComponent } from './button/button-hero.component';

--- a/src/playground/popover/popover-custom-component.component.html
+++ b/src/playground/popover/popover-custom-component.component.html
@@ -1,4 +1,4 @@
-<button class="btn btn-outline-primary"
+<button nbButton
         [nbPopover]="customComponent"
         [nbPopoverContext]="{text: 'Example context'}">
   Custom component

--- a/src/playground/popover/popover-custom-component.component.ts
+++ b/src/playground/popover/popover-custom-component.component.ts
@@ -7,7 +7,6 @@
 import { Component } from '@angular/core';
 import { NbDynamicToAddComponent } from '../shared/dynamic.component';
 
-
 @Component({
   selector: 'nb-popover-custom-component',
   templateUrl: './popover-custom-component.component.html',

--- a/src/playground/popover/popover-modes.component.html
+++ b/src/playground/popover/popover-modes.component.html
@@ -1,13 +1,13 @@
 <div class="btn-group btn-divided-group btn-outline-divided-group">
-  <button class="btn btn-outline-primary" nbPopover="Click Mode" nbPopoverMode="click">
+  <button nbButton outline nbPopover="Click Mode" nbPopoverMode="click">
     Click Mode
   </button>
 
-  <button class="btn btn-outline-primary" nbPopover="Hint Mode" nbPopoverMode="hint">
+  <button nbButton outline nbPopover="Hint Mode" nbPopoverMode="hint">
     Hint Mode
   </button>
 
-  <button class="btn btn-outline-primary" nbPopover="Hover Mode" nbPopoverMode="hover">
+  <button nbButton outline nbPopover="Hover Mode" nbPopoverMode="hover">
     Hover Mode
   </button>
 </div>

--- a/src/playground/popover/popover-placements.component.html
+++ b/src/playground/popover/popover-placements.component.html
@@ -1,23 +1,23 @@
-<button class="btn btn-outline-primary" nbPopover="Right Popover!" nbPopoverPlacement="right">
+<button nbButton outline nbPopover="Right Popover!" nbPopoverPlacement="right">
   Right
 </button>
 
-<button class="btn btn-outline-primary" nbPopover="Bottom Popover!" nbPopoverPlacement="bottom">
+<button nbButton outline nbPopover="Bottom Popover!" nbPopoverPlacement="bottom">
   Bottom
 </button>
 
-<button class="btn btn-outline-primary" nbPopover="Top Popover!" nbPopoverPlacement="top">
+<button nbButton outline nbPopover="Top Popover!" nbPopoverPlacement="top">
   Top
 </button>
 
-<button class="btn btn-outline-primary" nbPopover="Left Popover!" nbPopoverPlacement="left">
+<button nbButton outline nbPopover="Left Popover!" nbPopoverPlacement="left">
   Left
 </button>
 
-<button class="btn btn-outline-primary" nbPopover="Start Popover!" nbPopoverPlacement="start">
+<button nbButton outline nbPopover="Start Popover!" nbPopoverPlacement="start">
   Start
 </button>
 
-<button class="btn btn-outline-primary" nbPopover="End Popover!" nbPopoverPlacement="end">
+<button nbButton outline nbPopover="End Popover!" nbPopoverPlacement="end">
   End
 </button>

--- a/src/playground/popover/popover-placements.component.ts
+++ b/src/playground/popover/popover-placements.component.ts
@@ -15,7 +15,7 @@ import { Component } from '@angular/core';
       margin: 2rem 0;
       display: block;
     }
-    .btn {
+    button {
       margin: 1rem;
     }
   `],

--- a/src/playground/popover/popover-showcase.component.html
+++ b/src/playground/popover/popover-showcase.component.html
@@ -1,1 +1,1 @@
-<button class="btn btn-outline-primary" nbPopover="Hi, I'm popover!" nbPopoverPlacement="bottom">Open Popover</button>
+<button nbButton outline nbPopover="Hi, I'm popover!" nbPopoverPlacement="bottom">Open Popover</button>

--- a/src/playground/popover/popover-template-ref.component.html
+++ b/src/playground/popover/popover-template-ref.component.html
@@ -1,4 +1,4 @@
-<button class="btn btn-outline-primary"
+<button nbButton outline
         [nbPopover]="template"
         [nbPopoverContext]="{text: 'Example context'}"
         nbPopoverPlacement="right">

--- a/src/playground/popover/popover-test.component.ts
+++ b/src/playground/popover/popover-test.component.ts
@@ -14,7 +14,7 @@ import { NbDynamicToAddComponent } from '../shared/dynamic.component';
     <nb-card>
       <nb-card-header>Content Type</nb-card-header>
       <nb-card-body>
-        <button class="btn btn-info" [nbPopover]="popoverTemplate"
+        <button [nbPopover]="popoverTemplate"
                 [nbPopoverContext]="{text: 'Example context'}"
                 nbPopoverPlacement="right">
           Template Ref Test
@@ -47,22 +47,22 @@ import { NbDynamicToAddComponent } from '../shared/dynamic.component';
     <nb-card>
       <nb-card-header>Placement</nb-card-header>
       <nb-card-body>
-        <button class="btn btn-outline-secondary" nbPopover="Right Popover!" nbPopoverPlacement="right">
+        <button nbPopover="Right Popover!" nbPopoverPlacement="right">
           Right
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Bottom Popover!" nbPopoverPlacement="bottom">
+        <button nbPopover="Bottom Popover!" nbPopoverPlacement="bottom">
           Bottom
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Top Popover!" nbPopoverPlacement="top">
+        <button nbPopover="Top Popover!" nbPopoverPlacement="top">
           Top
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Left Popover!" nbPopoverPlacement="left">
+        <button nbPopover="Left Popover!" nbPopoverPlacement="left">
           Left
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Start Popover!" nbPopoverPlacement="start">
+        <button nbPopover="Start Popover!" nbPopoverPlacement="start">
           Start
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="End Popover!" nbPopoverPlacement="end">
+        <button nbPopover="End Popover!" nbPopoverPlacement="end">
           End
         </button>
       </nb-card-body>
@@ -70,52 +70,52 @@ import { NbDynamicToAddComponent } from '../shared/dynamic.component';
     <nb-card>
       <nb-card-header>Multiple Hints</nb-card-header>
       <nb-card-body>
-        <button class="btn btn-outline-secondary" nbPopover="Right Popover!" nbPopoverMode="hint">
+        <button nbPopover="Right Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Bottom Popover!" nbPopoverMode="hint">
+        <button nbPopover="Bottom Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Top Popover!" nbPopoverMode="hint">
+        <button nbPopover="Top Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Left Popover!" nbPopoverMode="hint">
+        <button nbPopover="Left Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Right Popover!" nbPopoverMode="hint">
+        <button nbPopover="Right Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Bottom Popover!" nbPopoverMode="hint">
+        <button nbPopover="Bottom Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Top Popover!" nbPopoverMode="hint">
+        <button nbPopover="Top Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Left Popover!" nbPopoverMode="hint">
+        <button nbPopover="Left Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Right Popover!" nbPopoverMode="hint">
+        <button nbPopover="Right Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Bottom Popover!" nbPopoverMode="hint">
+        <button nbPopover="Bottom Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Top Popover!" nbPopoverMode="hint">
+        <button nbPopover="Top Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Left Popover!" nbPopoverMode="hint">
+        <button nbPopover="Left Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Right Popover!" nbPopoverMode="hint">
+        <button nbPopover="Right Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Bottom Popover!" nbPopoverMode="hint">
+        <button nbPopover="Bottom Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Top Popover!" nbPopoverMode="hint">
+        <button nbPopover="Top Popover!" nbPopoverMode="hint">
           show hint
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Left Popover!" nbPopoverMode="hint">
+        <button nbPopover="Left Popover!" nbPopoverMode="hint">
           show hint
         </button>
       </nb-card-body>
@@ -123,13 +123,13 @@ import { NbDynamicToAddComponent } from '../shared/dynamic.component';
     <nb-card>
       <nb-card-header>Trigger mode</nb-card-header>
       <nb-card-body>
-        <button class="btn btn-outline-secondary" nbPopover="Click Popover!">
+        <button nbPopover="Click Popover!">
           Click
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Hover Popover!" nbPopoverMode="hover">
+        <button nbPopover="Hover Popover!" nbPopoverMode="hover">
           Hover
         </button>
-        <button class="btn btn-outline-secondary" nbPopover="Hint Popover!" nbPopoverMode="hint">
+        <button nbPopover="Hint Popover!" nbPopoverMode="hint">
           HInt
         </button>
       </nb-card-body>
@@ -137,7 +137,7 @@ import { NbDynamicToAddComponent } from '../shared/dynamic.component';
     <nb-card>
       <nb-card-header>Popover</nb-card-header>
       <nb-card-body>
-        <button class="btn btn-outline-success" nbPopover="Click Popover!">
+        <button nbPopover="Click Popover!">
           Show me popover
         </button>
       </nb-card-body>

--- a/src/playground/sidebar/sidebar-fixed.component.html
+++ b/src/playground/sidebar/sidebar-fixed.component.html
@@ -1,6 +1,6 @@
 <nb-layout>
   <nb-layout-header fixed>
-    <button class="btn btn-success btn-tn" (click)="toggle()">Toggle</button>
+    <button nbButton status="success" size="xsmall" (click)="toggle()">Toggle</button>
   </nb-layout-header>
   <nb-sidebar fixed></nb-sidebar>
 

--- a/src/playground/sidebar/sidebar-toggle.component.html
+++ b/src/playground/sidebar/sidebar-toggle.component.html
@@ -1,7 +1,7 @@
 <nb-layout>
   <nb-layout-header fixed>
-    <button class="btn btn-success btn-tn" (click)="toggle()">Toggle</button>
-    <button class="btn btn-info btn-tn" (click)="toggleCompact()">Toggle Compact</button>
+    <button nbButton status="success" size="xsmall" (click)="toggle()">Toggle</button>
+    <button nbButton status="info" size="xsmall" (click)="toggleCompact()">Toggle Compact</button>
   </nb-layout-header>
 
   <nb-sidebar tag="left"></nb-sidebar>

--- a/src/playground/spinner/spinner-button.component.ts
+++ b/src/playground/spinner/spinner-button.component.ts
@@ -12,32 +12,32 @@ import { Component } from '@angular/core';
      <nb-card accent="primary" size="small">
       <nb-card-body>
         <div class="d-flex align-items-start">
-          <button class="button-container btn btn-success btn-lg" (click)="toggleLoadingAnimation()"
+          <button nbButton status="success" size="large" (click)="toggleLoadingAnimation()"
                   [nbSpinner]="loading" nbSpinnerStatus="success" nbSpinnerSize="large" nbSpinnerMessage="">
             Download
           </button>
 
-          <button class="button-container btn btn-primary btn-lg" (click)="toggleLoadingAnimation()"
+          <button nbButton status="primary" size="large" (click)="toggleLoadingAnimation()"
                   [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large" nbSpinnerMessage="">
             Download
           </button>
 
-          <button class="button-container btn btn-warning btn-lg" (click)="toggleLoadingAnimation()"
+          <button nbButton status="warning" size="large" (click)="toggleLoadingAnimation()"
                   [nbSpinner]="loading" nbSpinnerStatus="warning" nbSpinnerSize="large" nbSpinnerMessage="">
             Download
           </button>
 
-          <button class="button-container btn btn-danger btn-md" (click)="toggleLoadingAnimation()"
+          <button nbButton status="danger" size="medium" (click)="toggleLoadingAnimation()"
                   [nbSpinner]="loading" nbSpinnerStatus="danger" nbSpinnerMessage="">
             Download
           </button>
 
-          <button class="button-container btn btn-info btn-md" (click)="toggleLoadingAnimation()"
+          <button nbButton status="info" size="medium" (click)="toggleLoadingAnimation()"
                   [nbSpinner]="loading" nbSpinnerStatus="info" nbSpinnerSize="small" nbSpinnerMessage="">
             Download
           </button>
 
-          <button class="button-container btn btn-info btn-sm" (click)="toggleLoadingAnimation()"
+          <button nbButton status="info" size="medium" (click)="toggleLoadingAnimation()"
                   [nbSpinner]="loading" nbSpinnerStatus="info" nbSpinnerSize="xsmall" nbSpinnerMessage="">
             Download
           </button>
@@ -46,7 +46,7 @@ import { Component } from '@angular/core';
     </nb-card>
   `,
   styles: [`
-    :host .button-container {
+    button {
       margin: 1rem;
     }
   `],

--- a/src/playground/spinner/spinner-card.component.ts
+++ b/src/playground/spinner/spinner-card.component.ts
@@ -10,7 +10,7 @@ import { Component } from '@angular/core';
           A nebula is an interstellar cloud of dust, hydrogen, helium and other ionized gases.
           Originally, nebula was a name for any diffuse astronomical object.
         </p>
-        <button class="btn btn-info btn-sm" (click)="toggleLoadingAnimation()">Reload</button>
+        <button nbButton status="info" size="small" (click)="toggleLoadingAnimation()">Reload</button>
 
       </nb-card-body>
     </nb-card>

--- a/src/playground/stepper/stepper-playground.component.scss
+++ b/src/playground/stepper/stepper-playground.component.scss
@@ -1,6 +1,6 @@
 :host ::ng-deep nb-stepper .step-content {
   text-align: center;
-  .btn {
+  button {
     cursor: pointer;
     margin: 0.5rem;
   }

--- a/src/playground/stepper/stepper-showcase.component.html
+++ b/src/playground/stepper/stepper-showcase.component.html
@@ -4,25 +4,25 @@
       <nb-step [label]="labelOne">
         <ng-template #labelOne>First step</ng-template>
         <h3>Step content #1</h3>
-        <button class="btn btn-primary" disabled nbStepperNext>prev</button>
-        <button class="btn btn-primary" nbStepperNext>next</button>
+        <button nbButton disabled nbStepperNext>prev</button>
+        <button nbButton nbStepperNext>next</button>
       </nb-step>
       <nb-step [label]="labelTwo">
         <ng-template #labelTwo>Second step</ng-template>
         <h3>Step content #2</h3>
-        <button class="btn btn-primary" nbStepperPrevious>prev</button>
-        <button class="btn btn-primary" nbStepperNext>next</button>
+        <button nbButton nbStepperPrevious>prev</button>
+        <button nbButton nbStepperNext>next</button>
       </nb-step>
       <nb-step label="Third step">
         <h3>Step content #3</h3>
-        <button class="btn btn-primary" nbStepperPrevious>prev</button>
-        <button class="btn btn-primary" nbStepperNext>next</button>
+        <button nbButton nbStepperPrevious>prev</button>
+        <button nbButton nbStepperNext>next</button>
       </nb-step>
       <nb-step [label]="labelFour">
         <ng-template #labelFour>Fourth step</ng-template>
         <h3>Step content #4</h3>
-        <button class="btn btn-primary" nbStepperPrevious>prev</button>
-        <button class="btn btn-primary" disabled nbStepperNext>next</button>
+        <button nbButton nbStepperPrevious>prev</button>
+        <button nbButton disabled nbStepperNext>next</button>
       </nb-step>
     </nb-stepper>
   </nb-card-body>

--- a/src/playground/stepper/stepper-validation.component.html
+++ b/src/playground/stepper/stepper-validation.component.html
@@ -11,7 +11,7 @@
             <input type="text" placeholder="Enter your name" class="form-control" formControlName="firstCtrl"
                    [ngClass]="{'form-control-danger': firstForm.invalid && (firstForm.dirty || firstForm.touched)}">
           </div>
-          <button class="btn btn-primary" nbStepperNext>next</button>
+          <button nbButton nbStepperNext>next</button>
         </form>
       </nb-step>
       <nb-step [stepControl]="secondForm" label="Second step">
@@ -25,8 +25,8 @@
             <input type="text" placeholder="Enter favorite movie" class="form-control" formControlName="secondCtrl"
                    [ngClass]="{'form-control-danger': secondForm.invalid && (secondForm.dirty || secondForm.touched)}">
           </div>
-          <button class="btn btn-primary" nbStepperPrevious>prev</button>
-          <button class="btn btn-primary" nbStepperNext>next</button>
+          <button nbButton nbStepperPrevious>prev</button>
+          <button nbButton nbStepperNext>next</button>
         </form>
       </nb-step>
       <nb-step [stepControl]="thirdForm" label="Third step">
@@ -38,14 +38,14 @@
             <input type="text" placeholder="Enter something" class="form-control" formControlName="thirdCtrl"
                    [ngClass]="{'form-control-danger': thirdForm.invalid && (thirdForm.dirty || thirdForm.touched)}">
           </div>
-          <button class="btn btn-primary" nbStepperPrevious>prev</button>
-          <button class="btn btn-primary" nbStepperNext>Confirm</button>
+          <button nbButton nbStepperPrevious>prev</button>
+          <button nbButton nbStepperNext>Confirm</button>
         </form>
       </nb-step>
       <nb-step [stepControl]="thirdForm" [hidden]="true" label="Third step">
         <div class="step-container">
           <h3>Wizard completed!</h3>
-          <button class="btn btn-primary" (click)="stepper.reset()">Try again</button>
+          <button nbButton (click)="stepper.reset()">Try again</button>
         </div>
       </nb-step>
     </nb-stepper>

--- a/src/playground/stepper/stepper-vertical.component.html
+++ b/src/playground/stepper/stepper-vertical.component.html
@@ -14,8 +14,8 @@
           sed ornare magna. Mauris vitae laoreet diam. Mauris fermentum ligula at lacinia semper. Nulla placerat dui
           eu sapien pellentesque, eu placerat leo luctus. Cras pharetra blandit fermentum.
         </p>
-        <button class="btn btn-primary" disabled nbStepperNext>prev</button>
-        <button class="btn btn-primary" nbStepperNext>next</button>
+        <button nbButton disabled nbStepperNext>prev</button>
+        <button nbButton nbStepperNext>next</button>
       </nb-step>
       <nb-step label="Second step">
         <h3>Step content #2</h3>
@@ -30,8 +30,8 @@
           sed ornare magna. Mauris vitae laoreet diam. Mauris fermentum ligula at lacinia semper. Nulla placerat dui
           eu sapien pellentesque, eu placerat leo luctus. Cras pharetra blandit fermentum.
         </p>
-        <button class="btn btn-primary" nbStepperPrevious>prev</button>
-        <button class="btn btn-primary" nbStepperNext>next</button>
+        <button nbButton nbStepperPrevious>prev</button>
+        <button nbButton nbStepperNext>next</button>
       </nb-step>
       <nb-step label="Third step">
         <h3>Step content #3</h3>
@@ -46,8 +46,8 @@
           sed ornare magna. Mauris vitae laoreet diam. Mauris fermentum ligula at lacinia semper. Nulla placerat dui
           eu sapien pellentesque, eu placerat leo luctus. Cras pharetra blandit fermentum.
         </p>
-        <button class="btn btn-primary" nbStepperPrevious>prev</button>
-        <button class="btn btn-primary" nbStepperNext>next</button>
+        <button nbButton nbStepperPrevious>prev</button>
+        <button nbButton nbStepperNext>next</button>
       </nb-step>
       <nb-step label="Fourth step">
         <h3>Step content #4</h3>
@@ -62,8 +62,8 @@
           sed ornare magna. Mauris vitae laoreet diam. Mauris fermentum ligula at lacinia semper. Nulla placerat dui
           eu sapien pellentesque, eu placerat leo luctus. Cras pharetra blandit fermentum.
         </p>
-        <button class="btn btn-primary" nbStepperPrevious>prev</button>
-        <button class="btn btn-primary" disabled nbStepperNext>next</button>
+        <button nbButton nbStepperPrevious>prev</button>
+        <button nbButton disabled nbStepperNext>next</button>
       </nb-step>
     </nb-stepper>
   </nb-card-body>


### PR DESCRIPTION
### Refresh token requests fully managed by NbAuthService & NbAuthJWTInterceptor

This pull requests intends to provide the necessary code so that refreshtoken requests are automatically sent to the backend when the local stored accesstoken has expired.
This allows the user not to type his login/password as long as his refresh-token is valid.
The refreshtoken requests are send transparently.

### Run it in the playground
You can easily test the code by calling the url http://localhost:4200/#/auth/call-api.
Then the AuthGuard service redirects you to the login page.

The strategy used to log in is Oauth2 with password grant-type, so you can use example@akveo.com.

You are logged with an access token whose ttl is 60 seconds and a refresh token whose ttl is 120 seconds.
These values can be modified in the configuration of the backend (config.js).

<img width="753" alt="capture d ecran 2018-07-13 a 08 15 51" src="https://user-images.githubusercontent.com/40032406/42676550-e573c98a-8678-11e8-9674-21efb47d7be1.png">

### Call of the secured api
Once logged, go immediately to http://localhost:4200/#/auth/call-api and click the call API button.

The XHR request is send with the authorization header containing Bearer + the access-token.
You can see that Alain's got good wines in his cellar.

<img width="527" alt="capture d ecran 2018-07-13 a 08 17 05" src="https://user-images.githubusercontent.com/40032406/42676592-0e6f157e-8679-11e8-9574-b1fddcb068e1.png">


### Automatic refresh-token request
Wait a minute, and click once again on the call-api button.

Observe the network logs of you browser : the acces-token was expired, so the framework sent automatically a refresh request to the backend.
<img width="802" alt="capture d ecran 2018-07-13 a 08 18 52" src="https://user-images.githubusercontent.com/40032406/42676647-3d98fe6e-8679-11e8-866b-3f8fb8a1e039.png">

It got a new access token, used in the call-api request.
<img width="630" alt="capture d ecran 2018-07-13 a 08 19 20" src="https://user-images.githubusercontent.com/40032406/42676687-5ff590b2-8679-11e8-9459-21ba05accbf0.png">

### Automatic redirect to login
If you wait once a minute, and if you click the call-api button, you are redirected to the login page, because refresh-token itself expired.

<img width="975" alt="capture d ecran 2018-07-13 a 08 19 39" src="https://user-images.githubusercontent.com/40032406/42676709-7541b7ac-8679-11e8-9eb6-7907e0b04886.png">

### Used principles
Originally, NbAuthService was not injected any strategy name used for login.
This implies that you have to give the strategy name when calling its refreshToken method.

I decided not to change this, and i had to store the strategy name used for login with the token itself (this makes sense, the token was obtained using a strategy name).
I also had to store in the token the expiration date because Oauth2 sends a expires-in property.

I modified unitary tests.

Hope you will like this work.




