### PR TITLE
fix(checkbox): fix disable state with reactive forms

### DIFF
--- a/src/framework/theme/components/checkbox/checkbox.component.ts
+++ b/src/framework/theme/components/checkbox/checkbox.component.ts
@@ -122,4 +122,8 @@ export class NbCheckboxComponent implements ControlValueAccessor {
   writeValue(val: any) {
     this.value = val;
   }
+
+  setDisabledState(val: boolean) {
+    this.disabled = convertToBoolProperty(val);
+  }
 }

--- a/src/framework/theme/components/checkbox/checkbox.spec.ts
+++ b/src/framework/theme/components/checkbox/checkbox.spec.ts
@@ -1,7 +1,8 @@
 import { NbCheckboxComponent } from './checkbox.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { DebugElement } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
+import { ReactiveFormsModule, FormControl } from '@angular/forms';
 
 describe('Component: NbCheckbox', () => {
 
@@ -65,5 +66,57 @@ describe('Component: NbCheckbox', () => {
     checkbox.status = 'danger';
     fixture.detectChanges();
     expect(testContainerEl.classList.contains('danger')).toBeTruthy();
+  });
+});
+
+/** Test component with reactive forms */
+@Component({
+  template: `<nb-checkbox [formControl]="formControl"></nb-checkbox>`,
+})
+class CheckboxWithFormControlComponent {
+  formControl = new FormControl();
+}
+
+describe('Component: NbCheckbox with form control', () => {
+
+  let fixture: ComponentFixture<CheckboxWithFormControlComponent>;
+  let checkboxComponent: DebugElement;
+  let checkboxInstance: NbCheckboxComponent;
+  let testComponent: CheckboxWithFormControlComponent;
+  let inputElement: HTMLInputElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      declarations: [NbCheckboxComponent, CheckboxWithFormControlComponent],
+    });
+
+      fixture = TestBed.createComponent(CheckboxWithFormControlComponent);
+      fixture.detectChanges();
+
+      checkboxComponent = fixture.debugElement.query(
+        By.directive(NbCheckboxComponent),
+      );
+      checkboxInstance = checkboxComponent.componentInstance;
+      testComponent = fixture.debugElement.componentInstance;
+      inputElement = <HTMLInputElement>(
+        checkboxComponent.nativeElement.querySelector('input')
+      );
+  });
+
+  it('Toggling form control disabled state properly toggles checkbox input', () => {
+      expect(checkboxInstance.disabled).toBeFalsy();
+
+      testComponent.formControl.disable();
+      fixture.detectChanges();
+
+      expect(checkboxInstance.disabled).toBeTruthy();
+      expect(inputElement.disabled).toBeTruthy();
+
+      testComponent.formControl.enable();
+      fixture.detectChanges();
+
+      expect(checkboxInstance.disabled).toBeFalsy();
+      expect(inputElement.disabled).toBeFalsy();
   });
 });


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
When using nb-checkbox with reactive forms, disabling the form control does not disable the underlying input. Implementing the `setDisabledState` method fixes this issue. See #296 for the initial report.