### PR TITLE
fix(auth): fix isAuthenticatedOrRefresh for empty tokens

### DIFF
--- a/src/framework/auth/services/auth.service.ts
+++ b/src/framework/auth/services/auth.service.ts
@@ -51,7 +51,7 @@ export class NbAuthService {
     return this.getToken()
       .pipe(
         switchMap(token => {
-        if (!token.isValid()) {
+        if (!token.isValid() && token.getOwnerStrategyName()) {
           return this.refreshToken(token.getOwnerStrategyName(), token)
             .pipe(
               switchMap(res => {

--- a/src/framework/auth/services/auth.spec.ts
+++ b/src/framework/auth/services/auth.spec.ts
@@ -31,7 +31,8 @@ describe('auth-service', () => {
   const resp200 = new HttpResponse<Object>({body: {}, status: 200});
 
   const testToken = nbAuthCreateToken(NbAuthSimpleToken, testTokenValue, ownerStrategyName);
-  const emptyToken = nbAuthCreateToken(NbAuthSimpleToken, null, ownerStrategyName);
+  const invalidToken = nbAuthCreateToken(NbAuthSimpleToken, null, ownerStrategyName);
+  const emptyToken = nbAuthCreateToken(NbAuthSimpleToken, null, null);
 
   const failResult = new NbAuthResult(false,
     resp401,
@@ -168,7 +169,7 @@ describe('auth-service', () => {
 
       spyOn(tokenService, 'get')
         .and
-        .returnValues(observableOf(emptyToken), observableOf(testToken));
+        .returnValues(observableOf(invalidToken), observableOf(testToken));
 
       authService.isAuthenticatedOrRefresh()
         .pipe(first())
@@ -187,7 +188,22 @@ describe('auth-service', () => {
 
       spyOn(tokenService, 'get')
         .and
-        .returnValues(observableOf(emptyToken), observableOf(emptyToken));
+        .returnValues(observableOf(invalidToken), observableOf(invalidToken));
+
+      authService.isAuthenticatedOrRefresh()
+        .pipe(first())
+        .subscribe((isAuth: boolean) => {
+          expect(spy).toHaveBeenCalled();
+          expect(isAuth).toBeFalsy();
+          done();
+        });
+    },
+  );
+
+  it('isAuthenticatedOrRefresh, token doesn\'t exist, strategy refreshToken called, returns false', (done) => {
+     const spy = spyOn(tokenService, 'get')
+        .and
+        .returnValue(observableOf(emptyToken));
 
       authService.isAuthenticatedOrRefresh()
         .pipe(first())


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
`isAuthenticatedOrRefresh()` fails if no token exists: 
```
ERROR TypeError: There is no Auth Strategy registered under '' name
```

This is because token.getOwnerStrategyName() will also be empty if there never was a token or it has been deleted by logout. This will fix that.