### PR TITLE
refactor(overlay): provide cdk adapters in forRoot

### DIFF
--- a/src/framework/theme/components/cdk/adapter/adapter.module.ts
+++ b/src/framework/theme/components/cdk/adapter/adapter.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { OverlayContainer, ScrollDispatcher } from '@angular/cdk/overlay';
 
 import { NbOverlayContainerAdapter } from './overlay-container-adapter';
@@ -7,14 +7,18 @@ import { NbViewportRulerAdapter } from './viewport-ruler-adapter';
 import { NbBlockScrollStrategyAdapter } from './block-scroll-strategy-adapter';
 
 
-@NgModule({
-  providers: [
-    NbViewportRulerAdapter,
-    NbOverlayContainerAdapter,
-    NbBlockScrollStrategyAdapter,
-    { provide: OverlayContainer, useExisting: NbOverlayContainerAdapter },
-    { provide: ScrollDispatcher, useClass: NbScrollDispatcherAdapter },
-  ],
-})
+@NgModule({})
 export class NbCdkAdapterModule {
+  static forRoot(): ModuleWithProviders {
+    return <ModuleWithProviders> {
+      ngModule: NbCdkAdapterModule,
+      providers: [
+        NbViewportRulerAdapter,
+        NbOverlayContainerAdapter,
+        NbBlockScrollStrategyAdapter,
+        { provide: OverlayContainer, useExisting: NbOverlayContainerAdapter },
+        { provide: ScrollDispatcher, useClass: NbScrollDispatcherAdapter },
+      ],
+    };
+  }
 }

--- a/src/framework/theme/components/cdk/overlay/overlay.module.ts
+++ b/src/framework/theme/components/cdk/overlay/overlay.module.ts
@@ -12,7 +12,6 @@ import { NbPositionHelper } from './position-helper';
 @NgModule({
   imports: [
     NbCdkMappingModule,
-    NbCdkAdapterModule,
     NbSharedModule,
   ],
   declarations: [NbOverlayContainerComponent],
@@ -29,6 +28,7 @@ export class NbOverlayModule {
         NbPositionBuilderService,
         NbOverlayService,
         NbPositionHelper,
+        ...NbCdkAdapterModule.forRoot().providers,
       ],
     };
   }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

`NbCdkAdapterModule` providers have to be provided once.