### PR TITLE
Fix bug where token wasn't being passed on request

### DIFF
--- a/src/framework/auth/services/auth.service.ts
+++ b/src/framework/auth/services/auth.service.ts
@@ -162,7 +162,7 @@ export class NbAuthService {
    * @returns {Observable<NbAuthResult>}
    */
   refreshToken(strategyName: string, data?: any): Observable<NbAuthResult> {
-    return this.getStrategy(strategyName).refreshToken()
+    return this.getStrategy(strategyName).refreshToken(data)
       .pipe(
         switchMap((result: NbAuthResult) => {
           return this.processResultToken(result);


### PR DESCRIPTION
On this version of Nebular auth, the token wasn't being passed on the request to the api due to missing parameter on the refresh token function, the request was always with it's body empty on the api side.

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
With the added missing parameter, now the token is passed on the body of the post request to the api.