### PR TITLE
fix(toastr): animations in firefox and edge

### DIFF
--- a/src/framework/theme/components/toastr/toastr-container.component.ts
+++ b/src/framework/theme/components/toastr/toastr-container.component.ts
@@ -17,7 +17,10 @@ import { takeWhile } from 'rxjs/operators';
 const voidState = style({
   transform: 'translateX({{ direction }}110%)',
   height: 0,
-  margin: 0,
+  marginLeft: '0',
+  marginRight: '0',
+  marginTop: '0',
+  marginBottom: '0',
 });
 
 const defaultOptions = { params: { direction: '' } };


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Angular animations have a bug. All properties have to be expanded to work properly in firefox and edge. So, I've just expanded the margin.

Closes #865