### PR TITLE
fix(overlay): hover trigger stop fire show if container already exists

### DIFF
--- a/src/framework/theme/components/cdk/overlay/overlay-trigger.spec.ts
+++ b/src/framework/theme/components/cdk/overlay/overlay-trigger.spec.ts
@@ -101,7 +101,9 @@ describe('hover-trigger-strategy', () => {
   });
 
   it('should fire show$ when hover on host', done => {
-    const triggerStrategy = triggerStrategyBuilder.build();
+    const triggerStrategy = triggerStrategyBuilder
+      .container(() => null)
+      .build();
     triggerStrategy.show$.subscribe(done);
     mouseEnter(host);
   });

--- a/src/framework/theme/components/cdk/overlay/overlay-trigger.ts
+++ b/src/framework/theme/components/cdk/overlay/overlay-trigger.ts
@@ -84,6 +84,7 @@ export class NbHoverTriggerStrategy extends NbTriggerStrategy {
 
   show$: Observable<Event> = observableFromEvent<Event>(this.host, 'mouseenter')
     .pipe(
+      filter(() => !this.container()),
       delay(100),
       takeUntil(observableFromEvent(this.host, 'mouseleave')),
       repeat(),


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Add filter to `NbHoverTrigger.show$` to stop firing show events if container already exists.

Closes #900 