### PR TITLE
Accept Partial of Component in NbDialogService open context

### DIFF
--- a/src/framework/theme/components/dialog/dialog.service.ts
+++ b/src/framework/theme/components/dialog/dialog.service.ts
@@ -150,7 +150,7 @@ export class NbDialogService {
   /**
    * Opens new instance of the dialog, may receive optional config.
    * */
-  open<T>(content: Type<T> | TemplateRef<T>, userConfig: Partial<NbDialogConfig<T>> = {}): NbDialogRef<T> {
+  open<T>(content: Type<T> | TemplateRef<T>, userConfig: Partial<NbDialogConfig<Partial<T>>> = {}): NbDialogRef<T> {
     const config = new NbDialogConfig({ ...this.globalConfig, ...userConfig });
     const overlayRef = this.createOverlay(config);
     const dialogRef = new NbDialogRef<T>(overlayRef);


### PR DESCRIPTION
When using Component in first param open method of NbDialogService, providing only certain properties of component in context property causes typescript errors.

### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
fix for #1173