### PR TITLE
fix(layout): typo in basic usage example

### DIFF
--- a/src/framework/theme/components/layout/layout.component.ts
+++ b/src/framework/theme/components/layout/layout.component.ts
@@ -183,7 +183,7 @@ export class NbLayoutFooterComponent {
  * ```html
  * <nb-layout>
  *  <nb-layout-header></nb-layout-header>
- *  <nb-layout-footer></nb-layout-column>
+ *  <nb-layout-footer></nb-layout-footer>
  *  <nb-layout-column></nb-layout-column>
  *  <nb-sidebar></nb-sidebar>
  * </nb-layout>


### PR DESCRIPTION
closes #1212 