### PR TITLE
fix the library's url of `login.component.html`

### DIFF
--- a/docs/articles/auth-custom-ui.md
+++ b/docs/articles/auth-custom-ui.md
@@ -251,7 +251,7 @@ export class NgxAuthRoutingModule {
 ```
 
 Now the most interesting part - as we need to modify the template, we can simply copy it from Nebular sources and adjust necessary parts.
-Unfortunately, the library isn't distributed with the sources, so we need to copy the template sources from [GitHub](https://github.com/akveo/nebular/blob/2.0.0/src/framework/auth/components/login/login.component.html). 
+Unfortunately, the library isn't distributed with the sources, so we need to copy the template sources from [GitHub](https://github.com/akveo/nebular/blob/v2.0.0/src/framework/auth/components/login/login.component.html). 
 
 <div class="note note-info">
   <div class="note-title">Note</div>


### PR DESCRIPTION
The library's url of `login.component.html` is wrong. Idk the reason why the url point to a 404 page in github. And I compareed the right url and wrong url. The difference of them is letter 'v'.

### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
