### PR TITLE
fix(select): select not rendering option wrapped in ng container

### DIFF
--- a/src/framework/theme/components/select/select.component.html
+++ b/src/framework/theme/components/select/select.component.html
@@ -28,6 +28,6 @@
 
 <nb-card *nbPortal class="select" [ngClass]="[status, overlayPosition]" [style.width.px]="hostWidth">
   <nb-card-body>
-    <ng-content select="nb-option, nb-option-group"></ng-content>
+    <ng-content select="nb-option, nb-option-group, ng-container"></ng-content>
   </nb-card-body>
 </nb-card>

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -225,7 +225,7 @@ describe('Component: NbSelectComponent', () => {
     })
   });
 
-  fit('should render option wrapped in ng-container', () => {
+  it('should render option wrapped in ng-container', () => {
     select.multiple = true;
     setSelectedAndOpen([]);
 

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -61,6 +61,9 @@ const TEST_GROUPS = [
           <nb-option-group *ngFor="let group of groups" [title]="group.title">
             <nb-option *ngFor="let option of group.options" [value]="option.value">{{ option.title }}</nb-option>
           </nb-option-group>
+          <ng-container *ngIf="groups">
+            <nb-option>ng-container option</nb-option>
+          </ng-container>
         </nb-select>
       </nb-layout-column>
     </nb-layout>
@@ -220,5 +223,14 @@ describe('Component: NbSelectComponent', () => {
       const button = fixture.nativeElement.querySelector('button');
       expect(button.textContent).toContain('1 noitpO');
     })
+  });
+
+  fit('should render option wrapped in ng-container', () => {
+    select.multiple = true;
+    setSelectedAndOpen([]);
+
+    const options = overlayContainer.querySelectorAll('nb-option');
+    const lastOption = options[options.length - 1];
+    expect(lastOption.textContent).toEqual('ng-container option');
   });
 });

--- a/src/playground/with-layout/select/select-showcase.component.html
+++ b/src/playground/with-layout/select/select-showcase.component.html
@@ -4,4 +4,3 @@
   <nb-option value="3">Option 3</nb-option>
   <nb-option value="4">Option 4</nb-option>
 </nb-select>
-


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
This fixes issue mentioned in https://github.com/akveo/nebular/issues/1063 related to `nb-select` not rendering `nb-options` that are wrapped in `ng-container`