### PR TITLE
refactor(cdk): destroy overlay triggers manually

### DIFF
--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.spec.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.spec.ts
@@ -9,6 +9,7 @@ import {
   Input,
   Type,
 } from '@angular/core';
+import { takeUntil } from 'rxjs/operators';
 
 import { NbRenderableContainer } from '../overlay-container';
 import {
@@ -146,6 +147,8 @@ export class MockTriggerStrategyBuilder {
   show$ = new Subject<any>();
   hide$ = new Subject<any>();
 
+  private destroyed$ = new Subject();
+
   trigger(trigger: NbTrigger): this {
     this._trigger = trigger;
     return this;
@@ -163,9 +166,10 @@ export class MockTriggerStrategyBuilder {
 
   build(): NbTriggerStrategy {
     return {
-      show$: this.show$,
-      hide$: this.hide$,
-    } as NbTriggerStrategy;
+      show$: this.show$.asObservable().pipe(takeUntil(this.destroyed$)),
+      hide$: this.hide$.asObservable().pipe(takeUntil(this.destroyed$)),
+      destroy: () => this.destroyed$.next(),
+    };
   }
 }
 

--- a/src/framework/theme/components/cdk/overlay/overlay-trigger.spec.ts
+++ b/src/framework/theme/components/cdk/overlay/overlay-trigger.spec.ts
@@ -82,6 +82,26 @@ describe('click-trigger-strategy', () => {
 
     expect(spy).toHaveBeenCalledTimes(0);
   });
+
+  it('should not destroy when host reattached', () => {
+    const showSpy = jasmine.createSpy('show');
+    const triggerStrategy = triggerStrategyBuilder
+      .container(() => null)
+      .build();
+
+    triggerStrategy.show$.subscribe(showSpy);
+
+    click(host);
+
+    expect(showSpy).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(host);
+    document.body.appendChild(host);
+
+    click(host);
+
+    expect(showSpy).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('hover-trigger-strategy', () => {
@@ -137,6 +157,32 @@ describe('hover-trigger-strategy', () => {
 
     expect(spy).toHaveBeenCalledTimes(0);
   });
+
+  it('should not destroy when host reattached', fakeAsync(() => {
+    const showSpy = jasmine.createSpy('show');
+    const triggerStrategy = triggerStrategyBuilder
+      .container(() => null)
+      .build();
+
+    triggerStrategy.show$.subscribe(showSpy);
+
+    mouseEnter(host);
+
+    // hover trigger strategy has 100 milliseconds delay before firing show$
+    tick(100);
+
+    expect(showSpy).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(host);
+    document.body.appendChild(host);
+
+    mouseEnter(host);
+
+    // hover trigger strategy has 100 milliseconds delay before firing show$
+    tick(100);
+
+    expect(showSpy).toHaveBeenCalledTimes(2);
+  }));
 });
 
 describe('hint-trigger-strategy', () => {
@@ -176,6 +222,31 @@ describe('hint-trigger-strategy', () => {
     triggerStrategy.hide$.subscribe(done);
     mouseLeave(host);
   });
+
+  it('should not destroy when host reattached', fakeAsync(() => {
+    const showSpy = jasmine.createSpy('show');
+    const triggerStrategy = triggerStrategyBuilder
+      .build();
+
+    triggerStrategy.show$.subscribe(showSpy);
+
+    mouseEnter(host);
+
+    // hint trigger strategy has 100 milliseconds delay before firing show$
+    tick(100);
+
+    expect(showSpy).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(host);
+    document.body.appendChild(host);
+
+    mouseEnter(host);
+
+    // hint trigger strategy has 100 milliseconds delay before firing show$
+    tick(100);
+
+    expect(showSpy).toHaveBeenCalledTimes(2);
+  }));
 });
 
 describe('focus-trigger-strategy', () => {
@@ -250,6 +321,32 @@ describe('focus-trigger-strategy', () => {
     tick(100);
 
     expect(showSpy).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should not destroy when host reattached', fakeAsync(() => {
+    const showSpy = jasmine.createSpy('show');
+    const triggerStrategy = triggerStrategyBuilder
+      .container(() => null)
+      .build();
+
+    triggerStrategy.show$.subscribe(showSpy);
+
+    focus(host);
+
+    // focus trigger strategy has 100 milliseconds delay before firing show$
+    tick(100);
+
+    expect(showSpy).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(host);
+    document.body.appendChild(host);
+
+    focus(host);
+
+    // focus trigger strategy has 100 milliseconds delay before firing show$
+    tick(100);
+
+    expect(showSpy).toHaveBeenCalledTimes(2);
   }));
 });
 

--- a/src/framework/theme/components/cdk/overlay/overlay-trigger.ts
+++ b/src/framework/theme/components/cdk/overlay/overlay-trigger.ts
@@ -208,7 +208,7 @@ export class NbFocusTriggerStrategy extends NbTriggerStrategyBase {
 /**
  * Creates empty show and hide event streams.
  * */
-export class NbDummyTriggerStrategy extends NbTriggerStrategyBase {
+export class NbNoopTriggerStrategy extends NbTriggerStrategyBase {
   show$: Observable<Event> = EMPTY;
   hide$: Observable<Event> = EMPTY;
 }
@@ -249,7 +249,7 @@ export class NbTriggerStrategyBuilderService {
       case NbTrigger.FOCUS:
         return new NbFocusTriggerStrategy(this._document, this._host, this._container);
       case NbTrigger.NOOP:
-        return new NbDummyTriggerStrategy(this._document, this._host, this._container);
+        return new NbNoopTriggerStrategy(this._document, this._host, this._container);
       default:
         throw new Error('Trigger have to be provided');
     }

--- a/src/framework/theme/components/datepicker/datepicker.component.ts
+++ b/src/framework/theme/components/datepicker/datepicker.component.ts
@@ -141,6 +141,11 @@ export abstract class NbBasePicker<D, T, P>
   protected positionStrategy: NbAdjustableConnectedPositionStrategy;
 
   /**
+   * Trigger strategy used by overlay
+   * */
+  protected triggerStrategy: NbTriggerStrategy;
+
+  /**
    * HTML input reference to which datepicker connected.
    * */
   protected hostRef: ElementRef;
@@ -232,6 +237,8 @@ export abstract class NbBasePicker<D, T, P>
     if (this.ref) {
       this.ref.dispose();
     }
+
+    this.triggerStrategy.destroy();
   }
 
   /**
@@ -314,9 +321,9 @@ export abstract class NbBasePicker<D, T, P>
   }
 
   protected subscribeOnTriggers() {
-    const triggerStrategy = this.createTriggerStrategy();
-    triggerStrategy.show$.pipe(takeWhile(() => this.alive)).subscribe(() => this.show());
-    triggerStrategy.hide$.pipe(takeWhile(() => this.alive)).subscribe(() => {
+    this.triggerStrategy = this.createTriggerStrategy();
+    this.triggerStrategy.show$.subscribe(() => this.show());
+    this.triggerStrategy.hide$.subscribe(() => {
       this.blur$.next();
       this.hide();
     });

--- a/src/framework/theme/components/select/select.component.ts
+++ b/src/framework/theme/components/select/select.component.ts
@@ -346,6 +346,7 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
     this.alive = false;
 
     this.ref.dispose();
+    this.triggerStrategy.destroy();
   }
 
   show() {
@@ -482,18 +483,13 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
   }
 
   protected subscribeOnTriggers() {
-    this.triggerStrategy.show$
-      .pipe(takeWhile(() => this.alive))
-      .subscribe(() => this.show());
-
-    this.triggerStrategy.hide$
-      .pipe(takeWhile(() => this.alive))
-      .subscribe(($event: Event) => {
-        this.hide();
-        if (!this.isClickedWithinComponent($event)) {
-          this.onTouched();
-        }
-      });
+    this.triggerStrategy.show$.subscribe(() => this.show());
+    this.triggerStrategy.hide$.subscribe(($event: Event) => {
+      this.hide();
+      if (!this.isClickedWithinComponent($event)) {
+        this.onTouched();
+      }
+    });
   }
 
   protected subscribeOnPositionChange() {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Closes #1289, #1292, #1290, #1292, #1273
Rewrite overlay triggers to close them manually calling **destroy()** method.