### PR TITLE
fix(option): emit selection change when selection is changed

### DIFF
--- a/src/framework/theme/components/select/option.component.ts
+++ b/src/framework/theme/components/select/option.component.ts
@@ -116,7 +116,7 @@ export class NbOptionComponent<T> implements OnDestroy {
     this.setSelection(false);
   }
 
-  private setSelection(isSelected: boolean): void {
+  private setSelection(selected: boolean): void {
     /**
      * In case of changing options in runtime the reference to the selected option will be kept in select component.
      * This may lead to exceptions with detecting changes in destroyed component.
@@ -124,8 +124,8 @@ export class NbOptionComponent<T> implements OnDestroy {
      * Also Angular can call writeValue on destroyed view (select implements ControlValueAccessor).
      * angular/angular#27803
      * */
-    if (this.alive && this.selected !== isSelected) {
-      this.selected = isSelected;
+    if (this.alive && this.selected !== selected) {
+      this.selected = selected;
       this.selectionChange.emit(this);
       this.cd.markForCheck();
     }

--- a/src/framework/theme/components/select/option.component.ts
+++ b/src/framework/theme/components/select/option.component.ts
@@ -18,6 +18,7 @@ import {
   OnDestroy,
   Output,
 } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
 import { convertToBoolProperty } from '../helpers';
 import { NbSelectComponent } from './select.component';
 
@@ -52,9 +53,17 @@ export class NbOptionComponent<T> implements OnDestroy {
   }
 
   /**
-   * Fires value on click.
+   * Fires value when option selection change.
    * */
   @Output() selectionChange: EventEmitter<NbOptionComponent<T>> = new EventEmitter();
+
+  /**
+   * Fires when option clicked
+   */
+  private click$: Subject<NbOptionComponent<T>> = new Subject<NbOptionComponent<T>>();
+  get click(): Observable<NbOptionComponent<T>> {
+    return this.click$.asObservable();
+  }
 
   selected: boolean = false;
   disabled: boolean = false;
@@ -84,19 +93,17 @@ export class NbOptionComponent<T> implements OnDestroy {
     return this.parent.multiple;
   }
 
-  @HostBinding('class.selected')
-  get selectedClass(): boolean {
+  @HostBinding('class.selected') get selectedClass(): boolean {
     return this.selected;
   }
 
-  @HostBinding('class.disabled')
-  get disabledClass(): boolean {
+  @HostBinding('class.disabled') get disabledClass(): boolean {
     return this.disabled;
   }
 
   @HostListener('click')
   onClick() {
-    this.selectionChange.emit(this);
+    this.click$.next(this);
   }
 
   select() {
@@ -115,10 +122,10 @@ export class NbOptionComponent<T> implements OnDestroy {
      * Also Angular can call writeValue on destroyed view (select implements ControlValueAccessor).
      * angular/angular#27803
      * */
-    if (this.alive) {
+    if (this.alive && this.selected !== isSelected) {
       this.selected = isSelected;
+      this.selectionChange.emit(this);
       this.cd.markForCheck();
     }
   }
 }
-

--- a/src/framework/theme/components/select/option.component.ts
+++ b/src/framework/theme/components/select/option.component.ts
@@ -93,11 +93,13 @@ export class NbOptionComponent<T> implements OnDestroy {
     return this.parent.multiple;
   }
 
-  @HostBinding('class.selected') get selectedClass(): boolean {
+  @HostBinding('class.selected')
+  get selectedClass(): boolean {
     return this.selected;
   }
 
-  @HostBinding('class.disabled') get disabledClass(): boolean {
+  @HostBinding('class.disabled')
+  get disabledClass(): boolean {
     return this.disabled;
   }
 

--- a/src/framework/theme/components/select/select.component.ts
+++ b/src/framework/theme/components/select/select.component.ts
@@ -566,7 +566,7 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
 
     // find options which were selected before and trigger deselect
     previouslySelectedOptions
-      .filter((option: NbOptionComponent<T>) => this.selectionModel.includes(option))
+      .filter((option: NbOptionComponent<T>) => !this.selectionModel.includes(option))
       .forEach((option: NbOptionComponent<T>) => option.deselect());
 
     this.cd.markForCheck();

--- a/src/framework/theme/components/select/select.component.ts
+++ b/src/framework/theme/components/select/select.component.ts
@@ -252,7 +252,6 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
    */
   overlayPosition: NbPosition = '' as NbPosition;
 
-  /* @deprecated */
   protected selectionChange$: Subject<NbOptionComponent<T>> = new Subject();
   /**
    * Stream of events that will fire when one of the options is clicked.

--- a/src/framework/theme/components/select/select.component.ts
+++ b/src/framework/theme/components/select/select.component.ts
@@ -26,7 +26,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { merge, Observable, Subject } from 'rxjs';
-import { takeWhile } from 'rxjs/operators';
+import { startWith, switchMap, takeWhile } from 'rxjs/operators';
 
 import {
   NbAdjustableConnectedPositionStrategy,
@@ -252,10 +252,14 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
    */
   overlayPosition: NbPosition = '' as NbPosition;
 
-  /**
-   * Stream of events that will fire when one of the options fire selectionChange event.
-   * */
+  /* @deprecated */
   protected selectionChange$: Subject<NbOptionComponent<T>> = new Subject();
+  /**
+   * Stream of events that will fire when one of the options is clicked.
+   * @deprecated
+   * Use nb-select (selected) binding to track selection change and <nb-option (click)=""> to track option click.
+   * @breaking-change 4.0.0
+   **/
   readonly selectionChange: Observable<NbOptionComponent<T>> = this.selectionChange$.asObservable();
 
   protected ref: NbOverlayRef;
@@ -339,7 +343,7 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
 
     this.subscribeOnTriggers();
     this.subscribeOnPositionChange();
-    this.subscribeOnSelectionChange();
+    this.subscribeOnOptionClick();
   }
 
   ngOnDestroy() {
@@ -391,7 +395,7 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
   /**
    * Selects option or clear all selected options if value is null.
    * */
-  protected handleSelect(option: NbOptionComponent<T>) {
+  protected handleOptionClick(option: NbOptionComponent<T>) {
     if (option.value) {
       this.selectOption(option);
     } else {
@@ -501,19 +505,24 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
       });
   }
 
-  protected subscribeOnSelectionChange() {
-    this.subscribeOnOptionsSelectionChange();
+  protected subscribeOnOptionClick() {
     /**
      * If the user changes provided options list in the runtime we have to handle this
      * and resubscribe on options selection changes event.
      * Otherwise, the user will not be able to select new options.
      * */
     this.options.changes
-      .subscribe(() => this.subscribeOnOptionsSelectionChange());
-
-    this.selectionChange
-      .pipe(takeWhile(() => this.alive))
-      .subscribe((option: NbOptionComponent<T>) => this.handleSelect(option));
+      .pipe(
+        startWith(this.options),
+        switchMap((options: QueryList<NbOptionComponent<T>>) => {
+          return merge(...options.map(option => option.click));
+        }),
+        takeWhile(() => this.alive),
+      )
+      .subscribe((clickedOption: NbOptionComponent<T>) => {
+        this.handleOptionClick(clickedOption);
+        this.selectionChange$.next(clickedOption);
+      });
   }
 
   protected getContainer() {
@@ -546,7 +555,8 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
       throw new Error('Can\'t assign array if select is not marked as multiple');
     }
 
-    this.cleanSelection();
+    const previouslySelectedOptions = this.selectionModel;
+    this.selectionModel = [];
 
     if (isArray) {
       (<T[]> value).forEach((option: T) => this.selectValue(option));
@@ -554,12 +564,12 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
       this.selectValue(<T> value);
     }
 
-    this.cd.markForCheck();
-  }
+    // find options which were selected before and trigger deselect
+    previouslySelectedOptions
+      .filter((option: NbOptionComponent<T>) => this.selectionModel.includes(option))
+      .forEach((option: NbOptionComponent<T>) => option.deselect());
 
-  protected cleanSelection() {
-    this.selectionModel.forEach((option: NbOptionComponent<T>) => option.deselect());
-    this.selectionModel = [];
+    this.cd.markForCheck();
   }
 
   /**
@@ -586,11 +596,5 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
 
   protected isClickedWithinComponent($event: Event) {
     return this.hostRef.nativeElement === $event.target || this.hostRef.nativeElement.contains($event.target as Node);
-  }
-
-  protected subscribeOnOptionsSelectionChange() {
-    merge(...this.options.map(it => it.selectionChange))
-      .pipe(takeWhile(() => this.alive))
-      .subscribe((change: NbOptionComponent<T>) => this.selectionChange$.next(change));
   }
 }

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -407,7 +407,7 @@ describe('Component: NbSelectComponent', () => {
 
     expect(selectionChangeSpy).not.toHaveBeenCalled();
   }));
-  
+
   it(`should not call dispose on uninitialized resources`, () => {
     const selectFixture = new NbSelectComponent(null, null, null, null, null, null);
     expect(() => selectFixture.ngOnDestroy()).not.toThrow();

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -324,9 +324,11 @@ describe('NbOptionComponent', () => {
     });
   });
 
-  it('should ignore selection change if destroyed', () => {
+  it('should ignore selection change if destroyed', fakeAsync(() => {
     const selectFixture = TestBed.createComponent(NbReactiveFormSelectComponent);
     const testSelectComponent = selectFixture.componentInstance;
+    selectFixture.detectChanges();
+    flush();
     selectFixture.detectChanges();
 
     const option = testSelectComponent.optionComponent;
@@ -344,11 +346,13 @@ describe('NbOptionComponent', () => {
     expect(() => testSelectComponent.formControl.setValue(2)).not.toThrow();
     expect(option.selected).toEqual(true);
     expect(markForCheckSpy).toHaveBeenCalledTimes(1);
-  });
+  }));
 
-  it('should emit selection change when changed through formControl binding', function() {
+  it('should emit selection change when changed through formControl binding', fakeAsync(() => {
     const selectFixture = TestBed.createComponent(NbReactiveFormSelectComponent);
     const testComponent = selectFixture.componentInstance;
+    selectFixture.detectChanges();
+    flush();
     selectFixture.detectChanges();
     const selectionChangeSpy = createSpy('selectionChangeSpy');
 
@@ -363,11 +367,13 @@ describe('NbOptionComponent', () => {
     expect(testComponent.optionComponent.selected).toEqual(true);
     expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
     expect(selectionChangeSpy).toHaveBeenCalledWith(testComponent.optionComponent);
-  });
+  }));
 
-  it('should emit selection change when changed through select selected binding', function() {
+  it('should emit selection change when changed through select selected binding', fakeAsync(() => {
     const selectFixture = TestBed.createComponent(NbSelectTestComponent);
     const testComponent = selectFixture.componentInstance;
+    selectFixture.detectChanges();
+    flush();
     selectFixture.detectChanges();
     const selectionChangeSpy = createSpy('selectionChangeSpy');
 
@@ -382,17 +388,18 @@ describe('NbOptionComponent', () => {
     expect(optionToSelect.selected).toEqual(true);
     expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
     expect(selectionChangeSpy).toHaveBeenCalledWith(optionToSelect);
-  });
+  }));
 
-  it('should emit selection change when changed through ngModel binding', function() {
+  it('should emit selection change when changed through ngModel binding', fakeAsync(() => {
     const selectFixture = TestBed.createComponent(NbNgModelSelectComponent);
     const testComponent = selectFixture.componentInstance;
-    selectFixture.detectChanges();
     const selectionChangeSpy = createSpy('selectionChangeSpy');
+    selectFixture.detectChanges();
+    flush();
+    selectFixture.detectChanges();
 
     testComponent.optionComponent.selectionChange
       .subscribe(selectionChangeSpy);
-
     expect(testComponent.optionComponent.selected).toEqual(false);
 
     testComponent.selectedValue = 1;
@@ -401,5 +408,5 @@ describe('NbOptionComponent', () => {
     expect(testComponent.optionComponent.selected).toEqual(true);
     expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
     expect(selectionChangeSpy).toHaveBeenCalledWith(testComponent.optionComponent);
-  });
+  }));
 });

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -123,7 +123,7 @@ export class NbReactiveFormSelectComponent {
     <nb-layout>
       <nb-layout-column>
 
-        <nb-select [ngModel]="selectedValue">
+        <nb-select [(ngModel)]="selectedValue">
           <nb-option *ngFor="let option of options" [value]="option">{{ option }}</nb-option>
         </nb-select>
 
@@ -403,6 +403,10 @@ describe('NbOptionComponent', () => {
     expect(testComponent.optionComponent.selected).toEqual(false);
 
     testComponent.selectedValue = 1;
+    selectFixture.detectChanges();
+    // need to call flush because NgModelDirective updates value on
+    // resolvedPromise.then
+    flush();
     selectFixture.detectChanges();
 
     expect(testComponent.optionComponent.selected).toEqual(true);

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -75,7 +75,7 @@ export class NbSelectTestComponent {
   @Input() customLabel: boolean;
   @Output() selectedChange: EventEmitter<any> = new EventEmitter();
   @ViewChild(NbSelectComponent) select: NbSelectComponent<any>;
-  @ViewChildren(NbSelectComponent) options: QueryList<NbOptionComponent<any>>;
+  @ViewChildren(NbOptionComponent) options: QueryList<NbOptionComponent<any>>;
   groups = TEST_GROUPS;
 }
 
@@ -382,7 +382,7 @@ describe('NbOptionComponent', () => {
       .subscribe(selectionChangeSpy);
     expect(optionToSelect.selected).toEqual(false);
 
-    testComponent.selected = optionToSelect;
+    testComponent.selected = optionToSelect.value;
     selectFixture.detectChanges();
 
     expect(optionToSelect.selected).toEqual(true);

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -391,7 +391,7 @@ describe('Component: NbSelectComponent', () => {
     expect(selectedOption.selected).toEqual(false);
   }));
 
-  it('should not change selection if option stays selected', fakeAsync(() => {
+  it('should not deselect option if option stays selected', fakeAsync(() => {
     const selectFixture = TestBed.createComponent(NbSelectTestComponent);
     const testSelectComponent = selectFixture.componentInstance;
     testSelectComponent.selected = TEST_GROUPS[0].options[0].value;
@@ -400,8 +400,7 @@ describe('Component: NbSelectComponent', () => {
     selectFixture.detectChanges();
 
     const selectedOption: NbOptionComponent<any> = testSelectComponent.options.find(o => o.selected);
-    const selectionChangeSpy = createSpy('selectionChangeSpy');
-    selectedOption.selectionChange.subscribe(selectionChangeSpy);
+    const selectionChangeSpy = spyOn(selectedOption, 'deselect');
 
     testSelectComponent.selected = selectedOption.value;
     selectFixture.detectChanges();


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Previously NbOptionComponent 'selectionChange' where emitted only when
option clicked, ignoring cases where select/deselect methods were called
from NbSelectComponent.

Also deprecates NbSelectComponent 'selectionChange' property.
We already has 'selectedChange' for this. Also 'selectionChange' name is
a bit confusing since it emits only when option clicked.
