### PR TITLE
fix(select): prevent dispose call on uninitialized properties

### DIFF
--- a/src/framework/theme/components/select/select.component.ts
+++ b/src/framework/theme/components/select/select.component.ts
@@ -345,8 +345,12 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
   ngOnDestroy() {
     this.alive = false;
 
-    this.ref.dispose();
-    this.triggerStrategy.destroy();
+    if (this.ref) {
+      this.ref.dispose();
+    }
+    if (this.triggerStrategy) {
+      this.triggerStrategy.destroy();
+    }
   }
 
   show() {

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -281,6 +281,11 @@ describe('Component: NbSelectComponent', () => {
     expect(selectButton.textContent).toEqual(selectedOption.value.toString());
   }));
 
+  it(`should not call dispose on initialized resources`, () => {
+    const selectFixture = new NbSelectComponent(null, null, null, null, null, null);
+    expect(() => selectFixture.ngOnDestroy()).not.toThrow();
+  });
+
   describe('NbOptionComponent', () => {
     it('should ignore selection change if destroyed', () => {
       const selectFixture = TestBed.createComponent(NbReactiveFormSelectComponent);

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -281,7 +281,7 @@ describe('Component: NbSelectComponent', () => {
     expect(selectButton.textContent).toEqual(selectedOption.value.toString());
   }));
 
-  it(`should not call dispose on initialized resources`, () => {
+  it(`should not call dispose on uninitialized resources`, () => {
     const selectFixture = new NbSelectComponent(null, null, null, null, null, null);
     expect(() => selectFixture.ngOnDestroy()).not.toThrow();
   });


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
#### Short description of what this resolves:
Fixes case when component was destroyed before calling init hook.