### PR TITLE
refactor(datepicker): support for ng 8

### DIFF
--- a/src/framework/theme/components/datepicker/datepicker.directive.ts
+++ b/src/framework/theme/components/datepicker/datepicker.directive.ts
@@ -13,6 +13,7 @@ import {
   Input,
   OnDestroy,
   ChangeDetectorRef,
+  Type,
 } from '@angular/core';
 import {
   ControlValueAccessor,
@@ -23,7 +24,6 @@ import {
   ValidatorFn,
   Validators,
 } from '@angular/forms';
-import { Type } from '@angular/core/src/type';
 import { fromEvent, Observable, merge } from 'rxjs';
 import { map, takeWhile, filter, take, tap } from 'rxjs/operators';
 


### PR DESCRIPTION
deep import of `Type` fails in ng 8 - importing from @angular/core works in 7 and 8.
