### PR TITLE
test(select): flush pending microtasks from other components

### DIFF
--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -309,6 +309,7 @@ describe('Component: NbSelectComponent', () => {
     const selectFixture = TestBed.createComponent(NbReactiveFormSelectComponent);
     const testSelectComponent = selectFixture.componentInstance;
     selectFixture.detectChanges();
+    flush();
 
     const setSelectionSpy = spyOn((testSelectComponent.selectComponent as any), 'setSelection').and.callThrough();
     testSelectComponent.showSelect = false;
@@ -322,6 +323,7 @@ describe('Component: NbSelectComponent', () => {
     const selectFixture = TestBed.createComponent(NbReactiveFormSelectComponent);
     const testComponent = selectFixture.componentInstance;
     selectFixture.detectChanges();
+    flush();
 
     const optionSelectSpy = spyOn(testComponent.optionComponent, 'select').and.callThrough();
 
@@ -338,6 +340,7 @@ describe('Component: NbSelectComponent', () => {
     const selectFixture = TestBed.createComponent(NbSelectTestComponent);
     const testComponent = selectFixture.componentInstance;
     selectFixture.detectChanges();
+    flush();
 
     const optionToSelect = testComponent.options.last;
     const optionSelectSpy = spyOn(optionToSelect, 'select').and.callThrough();


### PR DESCRIPTION
There is two task pending. One from button setTimeout and another from
spinner service.

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
There is two task pending. One from button setTimeout and another from
spinner service (I have no idea why spinner micro task showed up. It's code here since 2017).