### PR TITLE
fix(select): emit array when resetting multiple select

### DIFF
--- a/src/framework/theme/components/select/select.component.ts
+++ b/src/framework/theme/components/select/select.component.ts
@@ -416,7 +416,7 @@ export class NbSelectComponent<T> implements OnInit, AfterViewInit, AfterContent
     this.selectionModel = [];
     this.hide();
     this.button.nativeElement.focus();
-    this.emitSelected(null);
+    this.emitSelected(this.multiple ? [] : null);
   }
 
   /**

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -252,6 +252,31 @@ describe('Component: NbSelectComponent', () => {
     expect(overlayContainer.querySelectorAll('nb-option.selected').length).toBe(0);
   });
 
+  it('should emit selectionChange with empty array when reset option selected in multiple select', () => {
+    select.multiple = true;
+    setSelectedAndOpen(['Option 1', 'Option 2']);
+
+    const selectionChangeSpy = createSpy('selectionChangeSpy');
+    select.selectedChange.subscribe(selectionChangeSpy);
+
+    const option = overlayContainer.querySelector('nb-option');
+    option.dispatchEvent(new Event('click'));
+
+    expect(selectionChangeSpy).toHaveBeenCalledWith([]);
+  });
+
+  it('should emit selectionChange with null when reset option selected in single select', () => {
+    setSelectedAndOpen('Option 1');
+
+    const selectionChangeSpy = createSpy('selectionChangeSpy');
+    select.selectedChange.subscribe(selectionChangeSpy);
+
+    const option = overlayContainer.querySelector('nb-option');
+    option.dispatchEvent(new Event('click'));
+
+    expect(selectionChangeSpy).toHaveBeenCalledWith(null);
+  });
+
   it('should deselect only clicked item in multiple select', () => {
     select.multiple = true;
     setSelectedAndOpen(['Option 1', 'Option 2']);


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Reset emitted null as a select value for multiple select which caused `Can't assign a single value if select is marked as multiple` error when trying to set `null` value back (two-way data binding).