### PR TITLE
fix(docs): prefix root css urls with base path

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -251,6 +251,7 @@
             "main": "docs/main.ts",
             "tsConfig": "docs/tsconfig.app.json",
             "polyfills": "docs/polyfills.ts",
+            "rebaseRootRelativeCssUrls": true,
             "assets": [
               "docs/assets",
               "docs/404.html",


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Set `rebaseRootRelativeCssUrls` to enable legacy behavior when css absolute urls prefixed with base url. We need this until we have `/nebular/next` docs.

Prefixing removed in angular-cli#13684