### PR TITLE
fix(select): transparent gap between options

### DIFF
--- a/src/framework/theme/components/select/_select.component.theme.scss
+++ b/src/framework/theme/components/select/_select.component.theme.scss
@@ -49,6 +49,7 @@
   }
 
   .options-list {
+    background-color: nb-theme(select-option-background-color);
     max-height: nb-theme(select-options-list-max-height);
     height: 100%;
     overflow: auto;


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fixes transparent gap between options on iOS when zoomed in