### PR TITLE
fix(docs): wrong NbEvaIconsModule import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,7 +219,7 @@ There are two ways to upgrade:
 1) install Eva Icons Nebular package `npm i @nebular/eva-icons`
 2) register `NbEvaIconsModule` in the `app.module.ts`
 ```
-import { NbEvaIconsModule } form '@nebular/eva-icons';
+import { NbEvaIconsModule } from '@nebular/eva-icons';
 
 @NgModule({
   imports: [

--- a/docs/articles/migration/350-400.md
+++ b/docs/articles/migration/350-400.md
@@ -240,7 +240,7 @@ npm i @nebular/eva-icons
 
 2) register `NbEvaIconsModule` in the `app.module.ts`
 ```ts
-import { NbEvaIconsModule } form '@nebular/eva-icons';
+import { NbEvaIconsModule } from '@nebular/eva-icons';
 
 @NgModule({
   imports: [

--- a/src/framework/theme/components/icon/icon.component.ts
+++ b/src/framework/theme/components/icon/icon.component.ts
@@ -43,7 +43,7 @@ import { NbIconLibraries } from './icon-libraries';
  * This command will install Nebular Eva Icons pack. Then register `NbEvaIconsModule` into your app module or any child
  * module you need to have the icons in:
  * ```ts
- * import { NbEvaIconsModule } form '@nebular/eva-icons';
+ * import { NbEvaIconsModule } from '@nebular/eva-icons';
  *
  * @NgModule({
  *   imports: [


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
* Wrong import statement of NbEvaIconsModule (`form` ➡️ `from`)