### PR TITLE
fix(select): make options list same width as button

### DIFF
--- a/src/framework/theme/components/select/select.component.ts
+++ b/src/framework/theme/components/select/select.component.ts
@@ -651,7 +651,7 @@ export class NbSelectComponent<T> implements AfterViewInit, AfterContentInit, On
    * Returns width of the select button.
    * */
   get hostWidth(): number {
-    return this.hostRef.nativeElement.getBoundingClientRect().width;
+    return this.button.nativeElement.getBoundingClientRect().width;
   }
 
   get selectButtonClasses(): string[] {
@@ -864,7 +864,7 @@ export class NbSelectComponent<T> implements AfterViewInit, AfterContentInit, On
 
   protected createPositionStrategy(): NbAdjustableConnectedPositionStrategy {
     return this.positionBuilder
-      .connectedTo(this.hostRef)
+      .connectedTo(this.button)
       .position(NbPosition.BOTTOM)
       .offset(0)
       .adjustment(NbAdjustment.VERTICAL);

--- a/src/framework/theme/components/select/select.spec.ts
+++ b/src/framework/theme/components/select/select.spec.ts
@@ -575,6 +575,20 @@ describe('Component: NbSelectComponent', () => {
     const selectFixture = new NbSelectComponent(null, null, null, null, null, null);
     expect(() => selectFixture.ngOnDestroy()).not.toThrow();
   });
+
+  it(`should set overlay width same as button inside select`, () => {
+    const selectFixture = TestBed.createComponent(NbSelectComponent);
+    const selectComponent = selectFixture.componentInstance;
+    selectFixture.detectChanges();
+
+    const selectElement: HTMLElement = selectFixture.nativeElement;
+    const buttonElement: HTMLElement = selectElement.querySelector('button');
+
+    selectElement.style.padding = '1px';
+
+    expect(selectComponent.hostWidth).not.toEqual(selectElement.offsetWidth);
+    expect(selectComponent.hostWidth).toEqual(buttonElement.offsetWidth);
+  });
 });
 
 describe('NbSelectComponent - falsy values', () => {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fixes case when `nb-select` itself has padding leading to overlay being disconnected from a button or having width more than a button.