### PR TITLE
fix(select): add theme property for open select border

### DIFF
--- a/src/framework/theme/components/select/_select-outline.scss
+++ b/src/framework/theme/components/select/_select-outline.scss
@@ -63,6 +63,17 @@
       &[disabled] {
         border-color: nb-theme(select-outline-#{$status}-disabled-border-color);
       }
+
+      &.top {
+        border-top-color: nb-theme(select-outline-#{$status}-adjacent-border-color);
+        border-top-style: nb-theme(select-outline-#{$status}-adjacent-border-style);
+        border-top-width: nb-theme(select-outline-#{$status}-adjacent-border-width);
+      }
+      &.bottom {
+        border-bottom-color: nb-theme(select-outline-#{$status}-adjacent-border-color);
+        border-bottom-style: nb-theme(select-outline-#{$status}-adjacent-border-style);
+        border-bottom-width: nb-theme(select-outline-#{$status}-adjacent-border-width);
+      }
     }
 
     .options-list-container.appearance-outline.status-#{$status} {

--- a/src/framework/theme/components/select/_select-outline.scss
+++ b/src/framework/theme/components/select/_select-outline.scss
@@ -10,6 +10,11 @@
       color: nb-theme(select-outline-placeholder-text-color);
     }
 
+    &.bottom,
+    &.top {
+      border-color: nb-theme(select-open-outline-border-color);
+    }
+
     &.top {
       border-top-color: nb-theme(select-outline-adjacent-border-color);
       border-top-style: nb-theme(select-outline-adjacent-border-style);

--- a/src/framework/theme/styles/themes/_corporate.scss
+++ b/src/framework/theme/styles/themes/_corporate.scss
@@ -39,7 +39,7 @@ $theme: (
   accordion-shadow: none,
 
   select-options-list-border-width: 0.0625rem,
-  select-options-list-border-color: border-basic-color-3,
+  select-open-outline-border-color: select-options-list-outline-border-color,
 );
 
 $nb-themes: nb-register-theme($theme, corporate, default);

--- a/src/framework/theme/styles/themes/_mapping.scss
+++ b/src/framework/theme/styles/themes/_mapping.scss
@@ -1287,7 +1287,6 @@ $eva-mapping: (
   select-min-width: 13rem,
   select-options-list-max-height: 20rem,
   select-options-list-shadow: shadow,
-  select-options-list-border-color: transparent,
   select-options-list-border-style: solid,
   select-options-list-border-width: 0,
   select-outline-width: outline-width,

--- a/src/framework/theme/styles/themes/_mapping.scss
+++ b/src/framework/theme/styles/themes/_mapping.scss
@@ -1380,7 +1380,8 @@ $eva-mapping: (
   select-option-outline-large-padding: select-outline-large-padding,
   select-option-outline-giant-padding: select-outline-giant-padding,
 
-  select-outline-adjacent-border-color: select-outline-border-color,
+  select-open-outline-border-color: select-outline-border-color,
+  select-outline-adjacent-border-color: select-open-outline-border-color,
   select-outline-adjacent-border-style: select-outline-border-style,
   select-outline-adjacent-border-width: select-outline-border-width,
   select-outline-primary-adjacent-border-color: select-outline-primary-border-color,


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fixes select in corporate theme. Now both select and options list has same border.

Also removes `select-options-list-border-color` since it always overwritten by `select-<appearance>-options-list-border-color`.

And `select-outline-<status>-adjacent-border-color`, `select-outline-<status>-adjacent-border-style`, `select-outline-<status>-adjacent-border-width` theme variables were unused. I added appropriate styles for this properties.