### PR TITLE
docs(alert): specify a correct module to import

### DIFF
--- a/src/framework/theme/components/alert/alert.component.ts
+++ b/src/framework/theme/components/alert/alert.component.ts
@@ -26,7 +26,7 @@ import { convertToBoolProperty } from '../helpers';
  * ```
  * ### Installation
  *
- * Import `NbButtonModule` to your feature module.
+ * Import `NbAlertModule` to your feature module.
  * ```ts
  * @NgModule({
  *   imports: [


### PR DESCRIPTION
Import `NbButtonModule` to your feature module.
NbAlertModule must be imported not NbButtonModule

### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
