### PR TITLE
docs(menu): Fix selection highlight in menu service example

### DIFF
--- a/src/playground/with-layout/menu/menu-service-items.ts
+++ b/src/playground/with-layout/menu/menu-service-items.ts
@@ -39,8 +39,6 @@ export const MENU_ITEMS = [
             title: 'Commercial',
             link: '/example/menu/menu-service.component/3/3/2',
             icon: 'grid-outline',
-            queryParams: {param: 2},
-            fragment: 'fragment',
           },
         ],
       },


### PR DESCRIPTION
 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
---

Hello,

This is a very minor documentation fix.

I just noticed the menu service example doesn't correctly highlight one of the last items in the menu, presumably due to how the menu item is configured to match (i.e. full path by default).