### PR TITLE
chore(ci): remove unnecessary command

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "clean:lib": "rimraf src/.lib",
     "clean:all": "npm-run-all -p clean:tmp clean:lib",
     "ci:lint": "npm run lint && npm run lint:styles",
-    "ci:docs": "npm-run-all docs:prepare docs:build",
+    "ci:docs": "npm run docs:build",
     "ci:dev-deploy": "npm run firebase use dev && npm run firebase deploy",
     "ci:build": "npm-run-all -s build:prod build:package build:wp",
     "ci:test": "rimraf coverage && npm run build:package && npm run test:wp -- --code-coverage --watch=false && npm run test:schematics",


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
No need to run `docs:prepare` before `docs:build` as it's first command
of `docs:build`.