### PR TITLE
fix(layout): set header background color on host element

### DIFF
--- a/src/framework/theme/components/layout/_layout.component.theme.scss
+++ b/src/framework/theme/components/layout/_layout.component.theme.scss
@@ -177,6 +177,7 @@
   }
 
   nb-layout-header {
+    background-color: nb-theme(header-background-color);
     color: nb-theme(header-text-color);
     font-family: nb-theme(header-text-font-family);
     font-size: nb-theme(header-text-font-size);

--- a/src/framework/theme/components/layout/_layout.component.theme.scss
+++ b/src/framework/theme/components/layout/_layout.component.theme.scss
@@ -185,7 +185,6 @@
     line-height: nb-theme(header-text-line-height);
 
     nav {
-      background: nb-theme(header-background-color);
       color: nb-theme(header-text-color);
       box-shadow: nb-theme(header-shadow);
       height: nb-theme(header-height);


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fixes gaps between `nb-layout-header` and inner `nav` in cases when
`nav` width is smaller than `nb-layout-header` width.