### PR TITLE
fix(typography): declare text color classes at the bottom

### DIFF
--- a/src/framework/theme/styles/global/typography/_typography.scss
+++ b/src/framework/theme/styles/global/typography/_typography.scss
@@ -58,28 +58,6 @@
     line-height: nb-theme(text-paragraph-2-line-height);
   }
 
-  @each $status in nb-get-statuses() {
-    .text-#{$status} {
-      color: nb-theme(color-#{$status}-default);
-    }
-  }
-
-  .text-basic {
-    color: nb-theme(text-basic-color);
-  }
-  .text-alternate {
-    color: nb-theme(text-alternate-color);
-  }
-  .text-control {
-    color: nb-theme(text-control-color);
-  }
-  .text-disabled {
-    color: nb-theme(text-disabled-color);
-  }
-  .text-hint {
-    color: nb-theme(text-hint-color);
-  }
-
   a {
     color: nb-theme(link-text-color);
     font-size: inherit;
@@ -145,5 +123,27 @@
     font-size: nb-theme(list-item-font-size);
     font-weight: nb-theme(list-item-font-weight);
     line-height: nb-theme(list-item-line-height);
+  }
+
+  .text-basic {
+    color: nb-theme(text-basic-color);
+  }
+  .text-alternate {
+    color: nb-theme(text-alternate-color);
+  }
+  .text-control {
+    color: nb-theme(text-control-color);
+  }
+  .text-disabled {
+    color: nb-theme(text-disabled-color);
+  }
+  .text-hint {
+    color: nb-theme(text-hint-color);
+  }
+
+  @each $status in nb-get-statuses() {
+    .text-#{$status} {
+      color: nb-theme(color-#{$status}-default);
+    }
   }
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
This allows overriding elements text color who has it set since
selectors have the same weight but text color classes defined later.