### PR TITLE
refactor(checkbox): remove default padding

### DIFF
--- a/src/framework/theme/components/checkbox/_checkbox.component.theme.scss
+++ b/src/framework/theme/components/checkbox/_checkbox.component.theme.scss
@@ -6,6 +6,10 @@
 
 @mixin nb-checkbox-theme() {
   nb-checkbox {
+    .label {
+      padding: nb-theme(checkbox-padding);
+    }
+
     .custom-checkbox {
       width: nb-theme(checkbox-width);
       height: nb-theme(checkbox-height);

--- a/src/framework/theme/components/checkbox/_checkbox.component.theme.scss
+++ b/src/framework/theme/components/checkbox/_checkbox.component.theme.scss
@@ -4,6 +4,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
+@import '../../styles/core/mixins';
+
 @mixin nb-checkbox-theme() {
   nb-checkbox {
     .label {
@@ -85,6 +87,11 @@
       font-size: nb-theme(checkbox-text-font-size);
       font-weight: nb-theme(checkbox-text-font-weight);
       line-height: nb-theme(checkbox-text-line-height);
+
+      &:not(:empty) {
+        @include nb-ltr(padding-left, nb-theme(checkbox-text-space));
+        @include nb-rtl(padding-right, nb-theme(checkbox-text-space));
+      }
     }
   }
 

--- a/src/framework/theme/components/checkbox/checkbox.component.scss
+++ b/src/framework/theme/components/checkbox/checkbox.component.scss
@@ -7,7 +7,6 @@
     align-items: center;
     margin: 0;
     min-height: inherit;
-    padding: 0.375rem 1.5rem 0.375rem 0;
   }
 
   .custom-checkbox {

--- a/src/framework/theme/components/checkbox/checkbox.component.scss
+++ b/src/framework/theme/components/checkbox/checkbox.component.scss
@@ -16,7 +16,5 @@
 
   .text {
     transition: color 0.15s ease-in;
-    @include nb-ltr(padding-left, 0.6875rem);
-    @include nb-rtl(padding-right, 0.6875rem);
   }
 }

--- a/src/framework/theme/styles/themes/_mapping.scss
+++ b/src/framework/theme/styles/themes/_mapping.scss
@@ -892,6 +892,7 @@ $eva-mapping: (
   checkbox-text-font-size: text-subtitle-2-font-size,
   checkbox-text-font-weight: text-subtitle-2-font-weight,
   checkbox-text-line-height: text-subtitle-2-line-height,
+  checkbox-text-space: 0.6875rem,
   checkbox-padding: 0,
 
   checkbox-disabled-background-color: background-basic-color-2,

--- a/src/framework/theme/styles/themes/_mapping.scss
+++ b/src/framework/theme/styles/themes/_mapping.scss
@@ -892,6 +892,7 @@ $eva-mapping: (
   checkbox-text-font-size: text-subtitle-2-font-size,
   checkbox-text-font-weight: text-subtitle-2-font-weight,
   checkbox-text-line-height: text-subtitle-2-line-height,
+  checkbox-padding: 0,
 
   checkbox-disabled-background-color: background-basic-color-2,
   checkbox-disabled-border-color: border-basic-color-3,


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Extracts hardcoded paddings from component styles to theme properties.
Checkbox padding set to `0`.