### PR TITLE
fix(tabset): wrap lazy load content into template

### DIFF
--- a/src/framework/theme/components/tabset/tabset.component.ts
+++ b/src/framework/theme/components/tabset/tabset.component.ts
@@ -15,12 +15,22 @@ import {
   AfterContentInit,
   HostBinding,
   ChangeDetectorRef,
+  ContentChild,
+  TemplateRef,
+  Directive,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { convertToBoolProperty } from '../helpers';
 import { NbComponentStatus } from '../component-status';
 import { NbBadgePosition } from '../badge/badge.component';
+
+@Directive({
+  selector: '[nbTabLazyContent]',
+})
+export class NbTabLazyContentDirective {
+  constructor(public templateRef: TemplateRef<any>) {}
+}
 
 /**
  * Specific tab container.
@@ -36,8 +46,9 @@ import { NbBadgePosition } from '../badge/badge.component';
 @Component({
   selector: 'nb-tab',
   template: `
-    <ng-container *ngIf="init">
+    <ng-container *ngIf="active">
       <ng-content></ng-content>
+      <ng-container *ngTemplateOutlet="lazyContent?.templateRef"></ng-container>
     </ng-container>
   `,
 })
@@ -76,7 +87,6 @@ export class NbTabComponent {
   set responsive(val: boolean) {
     this.responsiveValue = convertToBoolProperty(val);
   }
-
   get responsive() {
     return this.responsiveValue;
   }
@@ -99,19 +109,6 @@ export class NbTabComponent {
   }
   set active(val: boolean) {
     this.activeValue = convertToBoolProperty(val);
-    if (this.activeValue) {
-      this.init = true;
-    }
-  }
-
-  /**
-   * Lazy load content before tab selection
-   * TODO: rename, as lazy is by default, and this is more `instant load`
-   * @param {boolean} val
-   */
-  @Input()
-  set lazyLoad(val: boolean) {
-    this.init = convertToBoolProperty(val);
   }
 
   /**
@@ -136,7 +133,7 @@ export class NbTabComponent {
    */
   @Input() badgePosition: NbBadgePosition;
 
-  init: boolean = false;
+  @ContentChild(NbTabLazyContentDirective, { static: false }) lazyContent: NbTabLazyContentDirective;
 }
 
 // TODO: Combine tabset with route-tabset, so that we can:

--- a/src/framework/theme/components/tabset/tabset.module.ts
+++ b/src/framework/theme/components/tabset/tabset.module.ts
@@ -8,13 +8,14 @@ import { NgModule } from '@angular/core';
 
 import { NbSharedModule } from '../shared/shared.module';
 
-import { NbTabsetComponent, NbTabComponent } from './tabset.component';
+import { NbTabsetComponent, NbTabComponent, NbTabLazyContentDirective } from './tabset.component';
 import { NbBadgeModule } from '../badge/badge.module';
 import { NbIconModule } from '../icon/icon.module';
 
 const NB_TABSET_COMPONENTS = [
   NbTabsetComponent,
   NbTabComponent,
+  NbTabLazyContentDirective,
 ];
 
 @NgModule({


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
TODO:
- update docs examples and text
- add/update tests on lazy loading
- probably we need to cache lazy content once it's initialized
- refactoring:
	- extract components into separate files
	- remove `<input-name>Value` public properties


BREAKING CHANGE:
Following `NbTabComponent` properties were removed:
- `init` - use `active` instead
- `lazyLoad` - instead wrap lazy content into `nb-template` with `nbTabLazyContent` directive.

Closes #1827, closes #1587.