### PR TITLE
fix(schematics): use cli version for schematics/angular package

### DIFF
--- a/src/framework/theme/schematics/ng-add/index.ts
+++ b/src/framework/theme/schematics/ng-add/index.ts
@@ -17,6 +17,7 @@ import {
   addDependencyToPackageJson,
   addDevDependencyToPackageJson,
   getDependencyVersionFromPackageJson,
+  getDevDependencyVersionFromPackageJson,
   getNebularPeerDependencyVersionFromPackageJson,
   getNebularVersion,
 } from '../util/package';
@@ -31,8 +32,9 @@ export default function (options: Schema): Rule {
 /**
  * Add required peer dependencies in package.json
  * */
-function installMainPeerDependencies(tree) {
+function installMainPeerDependencies(tree: Tree) {
   const angularCoreVersion = getDependencyVersionFromPackageJson(tree, '@angular/core');
+  const angularCliVersion = getDevDependencyVersionFromPackageJson(tree, '@angular/cli');
   const nebularThemeVersion = getNebularVersion();
   const angularCdkVersion = getNebularPeerDependencyVersionFromPackageJson('@angular/cdk');
 
@@ -41,7 +43,7 @@ function installMainPeerDependencies(tree) {
   addDependencyToPackageJson(tree, '@nebular/theme', nebularThemeVersion);
   addDependencyToPackageJson(tree, '@nebular/eva-icons', nebularThemeVersion);
 
-  addDevDependencyToPackageJson(tree, '@schematics/angular', angularCoreVersion);
+  addDevDependencyToPackageJson(tree, '@schematics/angular', angularCliVersion);
 }
 
 /**

--- a/src/framework/theme/schematics/util/package.ts
+++ b/src/framework/theme/schematics/util/package.ts
@@ -93,7 +93,7 @@ export function getDevDependencyVersionFromPackageJson(tree: Tree, packageName: 
 
   const packageJson: PackageJson = readJSON(tree, packageJsonName);
 
-  if (noInfoAboutDependency(packageJson, packageName)) {
+  if (noInfoAboutDevDependency(packageJson, packageName)) {
     throwNoPackageInfoInPackageJson(packageName);
   }
 
@@ -135,6 +135,13 @@ function noInfoAboutDependency(packageJson: PackageJson, packageName: string): b
 }
 
 /**
+ * Validates packageJson has devDependencies, also as specified devDependency not exists.
+ * */
+function noInfoAboutDevDependency(packageJson: PackageJson, packageName: string): boolean {
+  return !devDependencyAlreadyExists(packageJson, packageName);
+}
+
+/**
  * Validates packageJson has peerDependencies, also as specified peerDependency not exists.
  * */
 function noInfoAboutPeerDependency(packageJson: PackageJson, packageName: string): boolean {
@@ -146,6 +153,13 @@ function noInfoAboutPeerDependency(packageJson: PackageJson, packageName: string
  * */
 function dependencyAlreadyExists(packageJson: PackageJson, packageName: string): boolean {
   return !!(packageJson.dependencies && packageJson.dependencies[packageName]);
+}
+
+/**
+ * Validates packageJson has devDependencies, also as specified devDependency exists.
+ * */
+function devDependencyAlreadyExists(packageJson: PackageJson, packageName: string): boolean {
+  return !!(packageJson.devDependencies && packageJson.devDependencies[packageName]);
 }
 
 /**

--- a/src/framework/theme/schematics/util/package.ts
+++ b/src/framework/theme/schematics/util/package.ts
@@ -83,6 +83,23 @@ export function addDependencyToPackageJson(tree: Tree, packageName: string, pack
   writeJSON(tree, packageJsonName, packageJson);
 }
 
+/**
+ * Gets the version of the specified dev dependency by looking at the package.json in the specified tree
+ * */
+export function getDevDependencyVersionFromPackageJson(tree: Tree, packageName: string): string {
+  if (!tree.exists(packageJsonName)) {
+    throwNoPackageJsonError();
+  }
+
+  const packageJson: PackageJson = readJSON(tree, packageJsonName);
+
+  if (noInfoAboutDependency(packageJson, packageName)) {
+    throwNoPackageInfoInPackageJson(packageName);
+  }
+
+  return packageJson.devDependencies[packageName];
+}
+
 export function addDevDependencyToPackageJson(tree: Tree, packageName: string, packageVersion: string) {
   if (!tree.exists(packageJsonName)) {
     throwNoPackageJsonError();


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Using `angular/core` package version for `schematics/angular` it will sometimes raise "No matching version found" error because they are in sync only with the major versions. The `schematics` scoped packages are under the Angular CLI repo and they will be released together. By using the CLI version when add the `schematics/angular` package to the devDependencies we will, hopefully, be sure that the version exists and is published to npm.

Closes #1864