### PR TITLE
docs(context menu): remove extra character breaking overview text

### DIFF
--- a/src/framework/theme/components/context-menu/context-menu.directive.ts
+++ b/src/framework/theme/components/context-menu/context-menu.directive.ts
@@ -50,7 +50,7 @@ import { NbMenuItem, NbMenuService } from '../menu/menu.service';
  * export class PageModule { }
  * ```
  * Also make sure `NbMenuModule` is imported to your `app.module`.
- *  * ```ts
+ * ```ts
  * @NgModule({
  *   imports: [
  *     // ...


### PR DESCRIPTION
The documentation of this component at https://akveo.github.io/nebular/docs/components/context-menu/overview#nbcontextmenudirective is broken becasue an extra asterisk in the code.

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fix broken documentation at https://akveo.github.io/nebular/docs/components/context-menu/overview#nbcontextmenudirective