### PR TITLE
docs: skip repeating sources to avoid extra title producing

### DIFF
--- a/docs/app/@theme/services/structure.service.ts
+++ b/docs/app/@theme/services/structure.service.ts
@@ -93,9 +93,13 @@ export class NgdStructureService {
   }
 
   protected prepareComponent(component: any) {
-    const textNodes = component.overview.filter(node => node.type === 'text');
-    if (textNodes && textNodes.length) {
-      textNodes[0].content = `## ${component.name}\n\n${textNodes[0].content}`; // TODO: this is bad
+    if (!component.isPrepared) {
+      const textNodes = component.overview.filter(node => node.type === 'text');
+      if (textNodes && textNodes.length) {
+        textNodes[0].content = `## ${component.name}\n\n${textNodes[0].content}`; // TODO: this is bad
+      }
+      // Set isPrepared property to skip repeatin sources in structure.ts
+      component.isPrepared = true;
     }
     return {
       ... component,


### PR DESCRIPTION
If in `structure.ts` we have repeating sources, overview block of component page will produce repeating titles. To avoid this behaviour mark and skip already checked components (sources).
