### PR TITLE
feat(popover, tooltip): add shown state api

### DIFF
--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.spec.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.spec.ts
@@ -22,6 +22,7 @@ import { NbDynamicOverlay } from './dynamic-overlay';
 import { NbOverlayContent } from '../overlay-service';
 import { NbDynamicOverlayChange, NbDynamicOverlayHandler } from './dynamic-overlay-handler';
 import { NbTrigger, NbTriggerStrategy, NbTriggerStrategyBuilderService } from '../overlay-trigger';
+import { NbOverlayConfig } from '@nebular/theme/components/cdk/overlay/mapping';
 
 @Component({ template: '' })
 export class NbDynamicOverlayMockComponent implements NbRenderableContainer {
@@ -43,6 +44,7 @@ export class NbMockDynamicOverlay {
   _context: Object = {};
   _content: NbOverlayContent;
   _positionStrategy: NbAdjustableConnectedPositionStrategy;
+  _overlayConfig: NbOverlayConfig;
 
   constructor() {}
 
@@ -69,6 +71,10 @@ export class NbMockDynamicOverlay {
 
   setComponent(componentType: Type<NbRenderableContainer>) {
     this._componentType = componentType;
+  }
+
+  setOverlayConfig(overlayConfig: NbOverlayConfig) {
+    this._overlayConfig = overlayConfig;
   }
 
   setContentAndContext(content: NbOverlayContent, context: Object) {
@@ -515,5 +521,16 @@ describe('dynamic-overlay-handler', () => {
     expect(positionBuilder._connectedTo).toBe(host2);
     expect(positionBuilder._position).toBe(NbPosition.LEFT);
     expect(positionBuilder._adjustment).toBe(NbAdjustment.HORIZONTAL);
+  });
+
+  it('should set and update overlay config', () => {
+    let overlayConfig: NbOverlayConfig = { panelClass: 'custom-class' };
+
+    let dynamic = configure().overlayConfig(overlayConfig).build();
+    expect(dynamic._overlayConfig).toBe(jasmine.objectContaining(overlayConfig));
+
+    overlayConfig = { panelClass: 'other-custom-class' };
+    dynamic = configure().overlayConfig(overlayConfig).rebuild();
+    expect(dynamic._overlayConfig).toBe(jasmine.objectContaining(overlayConfig));
   });
 });

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.spec.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.spec.ts
@@ -51,12 +51,14 @@ export class NbMockDynamicOverlay {
   create(componentType: Type<NbRenderableContainer>,
          content: NbOverlayContent,
          context: Object,
-         positionStrategy: NbAdjustableConnectedPositionStrategy) {
+         positionStrategy: NbAdjustableConnectedPositionStrategy,
+         overlayConfig: NbOverlayConfig) {
 
     this.setContext(context);
     this.setContent(content);
     this.setComponent(componentType);
     this.setPositionStrategy(positionStrategy);
+    this.setOverlayConfig(overlayConfig);
 
     return this;
   }
@@ -527,10 +529,10 @@ describe('dynamic-overlay-handler', () => {
     let overlayConfig: NbOverlayConfig = { panelClass: 'custom-class' };
 
     let dynamic = configure().overlayConfig(overlayConfig).build();
-    expect(dynamic._overlayConfig).toBe(jasmine.objectContaining(overlayConfig));
+    expect(dynamic._overlayConfig).toEqual(jasmine.objectContaining(overlayConfig));
 
     overlayConfig = { panelClass: 'other-custom-class' };
     dynamic = configure().overlayConfig(overlayConfig).rebuild();
-    expect(dynamic._overlayConfig).toBe(jasmine.objectContaining(overlayConfig));
+    expect(dynamic._overlayConfig).toEqual(jasmine.objectContaining(overlayConfig));
   });
 });

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.ts
@@ -10,6 +10,7 @@ import {
 import { NbRenderableContainer } from '../overlay-container';
 import { NbOverlayContent } from '../overlay-service';
 import { NbDynamicOverlay } from './dynamic-overlay';
+import { NbOverlayConfig } from '../mapping';
 
 export class NbDynamicOverlayChange extends SimpleChange {
 
@@ -33,6 +34,7 @@ export class NbDynamicOverlayHandler {
   protected _position: NbPosition = NbPosition.TOP;
   protected _adjustment: NbAdjustment = NbAdjustment.NOOP;
   protected _offset: number = 15;
+  protected _overlayConfig: NbOverlayConfig = {};
 
   protected dynamicOverlay: NbDynamicOverlay;
   protected triggerStrategy: NbTriggerStrategy;
@@ -94,6 +96,12 @@ export class NbDynamicOverlayHandler {
     return this;
   }
 
+  overlayConfig(overlayConfig: NbOverlayConfig) {
+    this.changes.offset = new NbDynamicOverlayChange(this._overlayConfig, overlayConfig);
+    this._overlayConfig = overlayConfig;
+    return this;
+  }
+
   build() {
     if (!this._componentType || !this._host) {
       throw Error(`NbDynamicOverlayHandler: at least 'componentType' and 'host' should be
@@ -104,6 +112,7 @@ export class NbDynamicOverlayHandler {
       this._content,
       this._context,
       this.createPositionStrategy(),
+      this._overlayConfig,
     );
 
     this.connect();
@@ -137,6 +146,10 @@ export class NbDynamicOverlayHandler {
 
     if (this.isComponentTypeUpdateRequired()) {
       this.dynamicOverlay.setComponent(this._componentType);
+    }
+
+    if (this.isOverlayConfigUpdateRequired()) {
+      this.dynamicOverlay.setOverlayConfig(this._overlayConfig);
     }
 
     this.clearChanges();
@@ -203,6 +216,10 @@ export class NbDynamicOverlayHandler {
     return this.isComponentTypeUpdated();
   }
 
+  private isOverlayConfigUpdateRequired(): boolean {
+    return this.isOverlayConfigUpdated();
+  }
+
   protected isComponentTypeUpdated(): boolean {
     return this.changes.componentType && this.changes.componentType.isChanged();
   }
@@ -233,6 +250,10 @@ export class NbDynamicOverlayHandler {
 
   protected isOffsetUpdated(): boolean {
     return this.changes.offset && this.changes.offset.isChanged();
+  }
+
+  protected isOverlayConfigUpdated(): boolean {
+    return this.changes.overlayConfig && this.changes.overlayConfig.isChanged();
   }
 
   protected clearChanges() {

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay-handler.ts
@@ -97,7 +97,7 @@ export class NbDynamicOverlayHandler {
   }
 
   overlayConfig(overlayConfig: NbOverlayConfig) {
-    this.changes.offset = new NbDynamicOverlayChange(this._overlayConfig, overlayConfig);
+    this.changes.overlayConfig = new NbDynamicOverlayChange(this._overlayConfig, overlayConfig);
     this._overlayConfig = overlayConfig;
     return this;
   }

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.spec.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.spec.ts
@@ -319,14 +319,12 @@ describe('dynamic-overlay', () => {
   });
 
   it('should set component', () => {
-    const detachSpy = spyOn(ref, 'detach').and.callThrough();
     const disposeSpy = spyOn(ref, 'dispose').and.callThrough();
     const attachSpy = spyOn(ref, 'attach').and.callThrough();
     const hasAttacheSpy = spyOn(ref, 'hasAttached');
 
     dynamicOverlay.setComponent(NbDynamicOverlayMock2Component);
 
-    expect(detachSpy).toHaveBeenCalledTimes(0);
     expect(disposeSpy).toHaveBeenCalledTimes(0);
     expect(attachSpy).toHaveBeenCalledTimes(0);
 
@@ -334,14 +332,12 @@ describe('dynamic-overlay', () => {
     hasAttacheSpy.and.returnValue(true);
 
     expect(ref.portal.component).toBe(NbDynamicOverlayMock2Component);
-    expect(detachSpy).toHaveBeenCalledTimes(0);
     expect(disposeSpy).toHaveBeenCalledTimes(0);
     expect(attachSpy).toHaveBeenCalledTimes(1);
 
     dynamicOverlay.setComponent(NbDynamicOverlayMockComponent);
 
     expect(ref.portal.component).toBe(NbDynamicOverlayMockComponent);
-    expect(detachSpy).toHaveBeenCalledTimes(1);
     expect(disposeSpy).toHaveBeenCalledTimes(1);
     expect(attachSpy).toHaveBeenCalledTimes(2);
 
@@ -350,7 +346,6 @@ describe('dynamic-overlay', () => {
 
     dynamicOverlay.setComponent(NbDynamicOverlayMock2Component);
 
-    expect(detachSpy).toHaveBeenCalledTimes(3);
     expect(disposeSpy).toHaveBeenCalledTimes(2);
     expect(attachSpy).toHaveBeenCalledTimes(2);
   });

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.spec.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.spec.ts
@@ -267,6 +267,16 @@ describe('dynamic-overlay', () => {
     expect(instance.content).toBe(newContent);
   });
 
+  it('should set overlay config', () => {
+    const overlayConfig: NbOverlayConfig = { panelClass: 'additional-overlay-class' };
+    const createOverlaySpy = spyOn(overlayService, 'create').and.callThrough();
+
+    dynamicOverlay.setOverlayConfig(overlayConfig);
+    dynamicOverlay.show();
+
+    expect(createOverlaySpy).toHaveBeenCalledWith(jasmine.objectContaining(overlayConfig));
+  });
+
   it('should return container', () => {
     dynamicOverlay.show();
     expect(dynamicOverlay.getContainer()).toBe(container as any);

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
@@ -87,11 +87,10 @@ export class NbDynamicOverlay {
     this.componentType = componentType;
 
     // in case the component is shown we recreate it and show it back
-    if (this.ref && this.isAttached) {
-      this.dispose();
+    const wasAttached = this.isAttached;
+    this.disposeOverlayRef();
+    if (wasAttached) {
       this.show();
-    } else if (this.ref && !this.isAttached) {
-      this.dispose();
     }
   }
 

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
@@ -9,7 +9,7 @@ import {
 
 import { NbRenderableContainer } from '../overlay-container';
 import { createContainer, NbOverlayContent, NbOverlayService, patch } from '../overlay-service';
-import { NbOverlayRef, NbOverlayContainer } from '../mapping';
+import { NbOverlayRef, NbOverlayContainer, NbOverlayConfig } from '../mapping';
 
 export interface NbDynamicOverlayController {
   show();
@@ -27,6 +27,7 @@ export class NbDynamicOverlay {
   protected context: Object = {};
   protected content: NbOverlayContent;
   protected positionStrategy: NbAdjustableConnectedPositionStrategy;
+  protected overlayConfig: NbOverlayConfig = {};
 
   protected positionStrategyChange$ = new Subject();
   protected isShown$ = new BehaviorSubject<boolean>(false);
@@ -50,11 +51,13 @@ export class NbDynamicOverlay {
   create(componentType: Type<NbRenderableContainer>,
          content: NbOverlayContent,
          context: Object,
-         positionStrategy: NbAdjustableConnectedPositionStrategy) {
+         positionStrategy: NbAdjustableConnectedPositionStrategy,
+         overlayConfig: NbOverlayConfig = {}) {
 
     this.setContentAndContext(content, context);
     this.setComponent(componentType);
     this.setPositionStrategy(positionStrategy);
+    this.setOverlayConfig(overlayConfig);
 
     return this;
   }
@@ -112,6 +115,16 @@ export class NbDynamicOverlay {
     }
   }
 
+  setOverlayConfig(overlayConfig: NbOverlayConfig) {
+    this.overlayConfig = overlayConfig;
+
+    const wasAttached = this.isAttached;
+    this.disposeOverlayRef();
+    if (wasAttached) {
+      this.show();
+    }
+  }
+
   show() {
     if (!this.ref) {
       this.createOverlay();
@@ -163,6 +176,7 @@ export class NbDynamicOverlay {
     this.ref = this.overlay.create({
       positionStrategy: this.positionStrategy,
       scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      ...this.overlayConfig,
     });
     this.updatePositionWhenStable();
   }

--- a/src/framework/theme/components/popover/popover.directive.ts
+++ b/src/framework/theme/components/popover/popover.directive.ts
@@ -117,6 +117,8 @@ import { Subject } from 'rxjs';
 })
 export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges, AfterViewInit, OnDestroy, OnInit {
 
+  protected popoverComponent = NbPopoverComponent;
+
   /**
    * Popover content which will be rendered in NbArrowedOverlayContainerComponent.
    * Available content: template ref, component and any primitive.
@@ -175,7 +177,7 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
   ngOnInit() {
     this.dynamicOverlayHandler
       .host(this.hostRef)
-      .componentType(NbPopoverComponent);
+      .componentType(this.popoverComponent);
   }
 
   ngOnChanges() {

--- a/src/framework/theme/components/popover/popover.directive.ts
+++ b/src/framework/theme/components/popover/popover.directive.ts
@@ -118,6 +118,8 @@ import { Subject } from 'rxjs';
 export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges, AfterViewInit, OnDestroy, OnInit {
 
   protected popoverComponent = NbPopoverComponent;
+  protected dynamicOverlay: NbDynamicOverlay;
+  protected destroy$ = new Subject<void>();
 
   /**
    * Popover content which will be rendered in NbArrowedOverlayContainerComponent.
@@ -166,9 +168,6 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
   get isShown(): boolean {
     return !!(this.dynamicOverlay && this.dynamicOverlay.isAttached);
   }
-
-  protected dynamicOverlay: NbDynamicOverlay;
-  protected destroy$ = new Subject<void>();
 
   constructor(protected hostRef: ElementRef,
               protected dynamicOverlayHandler: NbDynamicOverlayHandler) {

--- a/src/framework/theme/components/popover/popover.directive.ts
+++ b/src/framework/theme/components/popover/popover.directive.ts
@@ -162,6 +162,9 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
   @Input('nbPopoverOffset')
   offset = 15;
 
+  @Input('nbPopoverClass')
+  popoverClass: string = '';
+
   @Output()
   nbPopoverShowStateChange = new EventEmitter<{ isShown: boolean }>();
 
@@ -225,6 +228,7 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
       .offset(this.offset)
       .adjustment(this.adjustment)
       .content(this.content)
-      .context(this.context);
+      .context(this.context)
+      .overlayConfig({ panelClass: this.popoverClass });
   }
 }

--- a/src/framework/theme/components/popover/popover.directive.ts
+++ b/src/framework/theme/components/popover/popover.directive.ts
@@ -146,6 +146,12 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
   @Input('nbPopoverTrigger')
   trigger: NbTrigger = NbTrigger.CLICK;
 
+  /**
+   * Sets popover offset
+   * */
+  @Input('nbPopoverOffset')
+  offset = 15;
+
   protected dynamicOverlay: NbDynamicOverlay;
 
   constructor(protected hostRef: ElementRef,
@@ -192,6 +198,7 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
     return this.dynamicOverlayHandler
       .position(this.position)
       .trigger(this.trigger)
+      .offset(this.offset)
       .adjustment(this.adjustment)
       .content(this.content)
       .context(this.context);

--- a/src/framework/theme/components/popover/popover.directive.ts
+++ b/src/framework/theme/components/popover/popover.directive.ts
@@ -146,10 +146,10 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
   @Input('nbPopoverTrigger')
   trigger: NbTrigger = NbTrigger.CLICK;
 
-  private dynamicOverlay: NbDynamicOverlay;
+  protected dynamicOverlay: NbDynamicOverlay;
 
-  constructor(private hostRef: ElementRef,
-              private dynamicOverlayHandler: NbDynamicOverlayHandler) {
+  constructor(protected hostRef: ElementRef,
+              protected dynamicOverlayHandler: NbDynamicOverlayHandler) {
   }
 
   ngOnInit() {

--- a/src/framework/theme/components/popover/popover.spec.ts
+++ b/src/framework/theme/components/popover/popover.spec.ts
@@ -12,6 +12,7 @@ import { NbTrigger } from '../cdk/overlay/overlay-trigger';
 import { NbPopoverDirective } from './popover.directive';
 import { NbPopoverComponent } from './popover.component';
 import { NbPopoverModule } from './popover.module';
+import createSpy = jasmine.createSpy;
 
 @Component({
   selector: 'nb-popover-component-content-test',
@@ -244,6 +245,56 @@ describe('Directive: NbPopoverDirective', () => {
       fixture.detectChanges();
       const templatePopover = fixture.nativeElement.querySelector('nb-popover');
       expect(templatePopover.textContent).toContain('hello world');
+    });
+
+    it('should emit show state change event when shows up', () => {
+      fixture = TestBed.createComponent(NbPopoverDefaultTestComponent);
+      fixture.detectChanges();
+      const popover: NbPopoverDirective = fixture.componentInstance.popover;
+
+      const stateChangeSpy = createSpy('stateChangeSpy');
+      popover.nbPopoverShowStateChange.subscribe(stateChangeSpy);
+
+      popover.show();
+      fixture.detectChanges();
+
+      expect(stateChangeSpy).toHaveBeenCalledTimes(1);
+      expect(stateChangeSpy).toHaveBeenCalledWith(jasmine.objectContaining({ isShown: true }));
+    });
+
+    it('should emit show state change event when hides', () => {
+      fixture = TestBed.createComponent(NbPopoverDefaultTestComponent);
+      fixture.detectChanges();
+      const popover: NbPopoverDirective = fixture.componentInstance.popover;
+      popover.show();
+      fixture.detectChanges();
+
+      const stateChangeSpy = createSpy('stateChangeSpy');
+      popover.nbPopoverShowStateChange.subscribe(stateChangeSpy);
+
+      popover.hide();
+      fixture.detectChanges();
+
+      expect(stateChangeSpy).toHaveBeenCalledTimes(1);
+      expect(stateChangeSpy).toHaveBeenCalledWith(jasmine.objectContaining({ isShown: false }));
+    });
+
+    it('should set isShown to false when hidden', () => {
+      fixture = TestBed.createComponent(NbPopoverDefaultTestComponent);
+      fixture.detectChanges();
+      const popover: NbPopoverDirective = fixture.componentInstance.popover;
+
+      expect(popover.isShown).toEqual(false);
+    });
+
+    it('should set isShown to true when shown', () => {
+      fixture = TestBed.createComponent(NbPopoverDefaultTestComponent);
+      fixture.detectChanges();
+      const popover: NbPopoverDirective = fixture.componentInstance.popover;
+      popover.show();
+      fixture.detectChanges();
+
+      expect(popover.isShown).toEqual(true);;
     });
 
   });

--- a/src/framework/theme/components/popover/popover.spec.ts
+++ b/src/framework/theme/components/popover/popover.spec.ts
@@ -294,7 +294,7 @@ describe('Directive: NbPopoverDirective', () => {
       popover.show();
       fixture.detectChanges();
 
-      expect(popover.isShown).toEqual(true);;
+      expect(popover.isShown).toEqual(true);
     });
 
   });

--- a/src/framework/theme/components/popover/popover.spec.ts
+++ b/src/framework/theme/components/popover/popover.spec.ts
@@ -13,6 +13,7 @@ import { NbPopoverDirective } from './popover.directive';
 import { NbPopoverComponent } from './popover.component';
 import { NbPopoverModule } from './popover.module';
 import createSpy = jasmine.createSpy;
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'nb-popover-component-content-test',
@@ -83,11 +84,13 @@ export class NbPopoverInstanceTestComponent {
   @ViewChild(TemplateRef, { static: false }) template: TemplateRef<any>;
 }
 
+const dynamicOverlayIsShow$ = new Subject();
 const dynamicOverlay = {
   show() {},
   hide() {},
   toggle() {},
   destroy() {},
+  isShown: dynamicOverlayIsShow$,
 };
 
 export class NbDynamicOverlayHandlerMock {
@@ -98,6 +101,7 @@ export class NbDynamicOverlayHandlerMock {
   _trigger: NbTrigger = NbTrigger.NOOP;
   _position: NbPosition = NbPosition.TOP;
   _adjustment: NbAdjustment = NbAdjustment.NOOP;
+  _offset = 15;
 
   constructor() {
   }
@@ -114,6 +118,11 @@ export class NbDynamicOverlayHandlerMock {
 
   position(position: NbPosition) {
     this._position = position;
+    return this;
+  }
+
+  offset(offset: number) {
+    this._offset = offset;
     return this;
   }
 

--- a/src/framework/theme/components/popover/popover.spec.ts
+++ b/src/framework/theme/components/popover/popover.spec.ts
@@ -14,6 +14,7 @@ import { NbPopoverComponent } from './popover.component';
 import { NbPopoverModule } from './popover.module';
 import createSpy = jasmine.createSpy;
 import { Subject } from 'rxjs';
+import { NbOverlayConfig } from '@nebular/theme/components/cdk/overlay/mapping';
 
 @Component({
   selector: 'nb-popover-component-content-test',
@@ -28,7 +29,7 @@ export class NbPopoverComponentContentTestComponent {
   template: `
     <nb-layout>
       <nb-layout-column>
-        <button #button nbPopover="test">show popover</button>
+        <button #button nbPopover="test" [nbPopoverClass]="popoverClass">show popover</button>
       </nb-layout-column>
     </nb-layout>
   `,
@@ -36,6 +37,8 @@ export class NbPopoverComponentContentTestComponent {
 export class NbPopoverDefaultTestComponent {
   @ViewChild('button', { static: false }) button: ElementRef;
   @ViewChild(NbPopoverDirective, { static: false }) popover: NbPopoverDirective;
+
+  popoverClass = '';
 }
 
 @Component({
@@ -102,6 +105,7 @@ export class NbDynamicOverlayHandlerMock {
   _position: NbPosition = NbPosition.TOP;
   _adjustment: NbAdjustment = NbAdjustment.NOOP;
   _offset = 15;
+  _overlayConfig: NbOverlayConfig = {};
 
   constructor() {
   }
@@ -143,6 +147,11 @@ export class NbDynamicOverlayHandlerMock {
 
   context(context: {}) {
     this._context = context;
+    return this;
+  }
+
+  overlayConfig(overlayConfig: NbOverlayConfig) {
+    this._overlayConfig = overlayConfig;
     return this;
   }
 
@@ -395,6 +404,17 @@ describe('Directive: NbPopoverDirective', () => {
         expect(showSpy).toHaveBeenCalledTimes(1);
         expect(hideSpy).toHaveBeenCalledTimes(1);
         expect(toggleSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('should set overlay config', () => {
+        const popoverClass = 'custom-popover-class';
+        const overlayConfigSpy = spyOn(overlayHandler, 'overlayConfig').and.callThrough();
+
+        fixture = TestBed.createComponent(NbPopoverDefaultTestComponent);
+        fixture.componentInstance.popoverClass = popoverClass;
+        fixture.detectChanges();
+
+        expect(overlayConfigSpy).toHaveBeenCalledWith(jasmine.objectContaining({ panelClass: popoverClass }));
       });
     });
 

--- a/src/framework/theme/components/tooltip/tooltip.directive.ts
+++ b/src/framework/theme/components/tooltip/tooltip.directive.ts
@@ -98,6 +98,9 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
   @Input('nbTooltipAdjustment')
   adjustment: NbAdjustment = NbAdjustment.CLOCKWISE;
 
+  @Input('nbTooltipClass')
+  tooltipClass: string = '';
+
   /**
    * Accepts icon name or icon config object
    * @param {string | NbIconConfig} icon name or config object
@@ -186,6 +189,7 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
       .trigger(this.trigger)
       .adjustment(this.adjustment)
       .content(this.content)
-      .context(this.context);
+      .context(this.context)
+      .overlayConfig({ panelClass: this.tooltipClass });
   }
 }

--- a/src/framework/theme/components/tooltip/tooltip.directive.ts
+++ b/src/framework/theme/components/tooltip/tooltip.directive.ts
@@ -4,7 +4,15 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-import { AfterViewInit, Directive, ElementRef, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import {
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 
 import { NbComponentStatus } from '../component-status';
 import { NbAdjustment, NbPosition } from '../cdk/overlay/overlay-position';
@@ -60,8 +68,11 @@ import { NbIconConfig } from '../icon/icon.component';
 })
 export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnDestroy {
 
-  context: Object = {};
+  protected tooltipComponent = NbTooltipComponent;
+  protected dynamicOverlay: NbDynamicOverlay;
+  protected offset = 8;
 
+  context: Object = {};
   /**
    * Tooltip message
    */
@@ -106,17 +117,15 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
   @Input('nbTooltipTrigger')
   trigger: NbTrigger = NbTrigger.HINT;
 
-  private dynamicOverlay: NbDynamicOverlay;
-
-  constructor(private hostRef: ElementRef,
-              private dynamicOverlayHandler: NbDynamicOverlayHandler) {
+  constructor(protected hostRef: ElementRef,
+              protected dynamicOverlayHandler: NbDynamicOverlayHandler) {
   }
 
   ngOnInit() {
     this.dynamicOverlayHandler
       .host(this.hostRef)
-      .componentType(NbTooltipComponent)
-      .offset(8);
+      .componentType(this.tooltipComponent)
+      .offset(this.offset);
   }
 
   ngOnChanges() {

--- a/src/framework/theme/components/tooltip/tooltip.directive.ts
+++ b/src/framework/theme/components/tooltip/tooltip.directive.ts
@@ -127,7 +127,7 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
   trigger: NbTrigger = NbTrigger.HINT;
 
   @Output()
-  nbPopoverShowStateChange = new EventEmitter<{ isShown: boolean }>();
+  nbTooltipShowStateChange = new EventEmitter<{ isShown: boolean }>();
 
   get isShown(): boolean {
     return !!(this.dynamicOverlay && this.dynamicOverlay.isAttached);
@@ -157,7 +157,7 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
         skip(1),
         takeUntil(this.destroy$),
       )
-      .subscribe((isShown: boolean) => this.nbPopoverShowStateChange.emit({ isShown }));
+      .subscribe((isShown: boolean) => this.nbTooltipShowStateChange.emit({ isShown }));
   }
 
   rebuild() {

--- a/src/framework/theme/components/tooltip/tooltip.spec.ts
+++ b/src/framework/theme/components/tooltip/tooltip.spec.ts
@@ -279,7 +279,7 @@ describe('Directive: NbTooltipDirective', () => {
       const tooltip: NbTooltipDirective = fixture.componentInstance.tooltip;
 
       const stateChangeSpy = createSpy('stateChangeSpy');
-      tooltip.nbPopoverShowStateChange.subscribe(stateChangeSpy);
+      tooltip.nbTooltipShowStateChange.subscribe(stateChangeSpy);
 
       tooltip.show();
       fixture.detectChanges();
@@ -296,7 +296,7 @@ describe('Directive: NbTooltipDirective', () => {
       fixture.detectChanges();
 
       const stateChangeSpy = createSpy('stateChangeSpy');
-      tooltip.nbPopoverShowStateChange.subscribe(stateChangeSpy);
+      tooltip.nbTooltipShowStateChange.subscribe(stateChangeSpy);
 
       tooltip.hide();
       fixture.detectChanges();

--- a/src/framework/theme/components/tooltip/tooltip.spec.ts
+++ b/src/framework/theme/components/tooltip/tooltip.spec.ts
@@ -14,6 +14,8 @@ import { NbTooltipDirective } from './tooltip.directive';
 import { NbTooltipModule } from './tooltip.module';
 import { NbTooltipComponent } from './tooltip.component';
 import { NbIconLibraries } from '../icon/icon-libraries';
+import { Subject } from 'rxjs';
+import createSpy = jasmine.createSpy;
 
 @Component({
   selector: 'nb-tooltip-default-test',
@@ -74,11 +76,13 @@ export class NbTooltipInstanceTestComponent {
   @ViewChild('button', { static: false }) button: ElementRef;
 }
 
+const dynamicOverlayIsShow$ = new Subject();
 const dynamicOverlay = {
   show() {},
   hide() {},
   toggle() {},
   destroy() {},
+  isShown: dynamicOverlayIsShow$,
 };
 
 export class NbDynamicOverlayHandlerMock {
@@ -258,6 +262,56 @@ describe('Directive: NbTooltipDirective', () => {
 
       const iconContainer = fixture.nativeElement.querySelector('nb-tooltip');
       expect(iconContainer.className).toContain('status-danger');
+    });
+
+    it('should emit show state change event when shows up', () => {
+      fixture = TestBed.createComponent(NbTooltipDefaultTestComponent);
+      fixture.detectChanges();
+      const tooltip: NbTooltipDirective = fixture.componentInstance.tooltip;
+
+      const stateChangeSpy = createSpy('stateChangeSpy');
+      tooltip.nbPopoverShowStateChange.subscribe(stateChangeSpy);
+
+      tooltip.show();
+      fixture.detectChanges();
+
+      expect(stateChangeSpy).toHaveBeenCalledTimes(1);
+      expect(stateChangeSpy).toHaveBeenCalledWith(jasmine.objectContaining({ isShown: true }));
+    });
+
+    it('should emit show state change event when hides', () => {
+      fixture = TestBed.createComponent(NbTooltipDefaultTestComponent);
+      fixture.detectChanges();
+      const tooltip: NbTooltipDirective = fixture.componentInstance.tooltip;
+      tooltip.show();
+      fixture.detectChanges();
+
+      const stateChangeSpy = createSpy('stateChangeSpy');
+      tooltip.nbPopoverShowStateChange.subscribe(stateChangeSpy);
+
+      tooltip.hide();
+      fixture.detectChanges();
+
+      expect(stateChangeSpy).toHaveBeenCalledTimes(1);
+      expect(stateChangeSpy).toHaveBeenCalledWith(jasmine.objectContaining({ isShown: false }));
+    });
+
+    it('should set isShown to false when hidden', () => {
+      fixture = TestBed.createComponent(NbTooltipDefaultTestComponent);
+      fixture.detectChanges();
+      const tooltip: NbTooltipDirective = fixture.componentInstance.tooltip;
+
+      expect(tooltip.isShown).toEqual(false);
+    });
+
+    it('should set isShown to true when shown', () => {
+      fixture = TestBed.createComponent(NbTooltipDefaultTestComponent);
+      fixture.detectChanges();
+      const tooltip: NbTooltipDirective = fixture.componentInstance.tooltip;
+      tooltip.show();
+      fixture.detectChanges();
+
+      expect(tooltip.isShown).toEqual(true);
     });
 
   });

--- a/src/framework/theme/components/tooltip/tooltip.spec.ts
+++ b/src/framework/theme/components/tooltip/tooltip.spec.ts
@@ -16,6 +16,7 @@ import { NbTooltipComponent } from './tooltip.component';
 import { NbIconLibraries } from '../icon/icon-libraries';
 import { Subject } from 'rxjs';
 import createSpy = jasmine.createSpy;
+import { NbOverlayConfig } from '@nebular/theme/components/cdk/overlay/mapping';
 
 @Component({
   selector: 'nb-tooltip-default-test',
@@ -42,7 +43,8 @@ export class NbTooltipDefaultTestComponent {
           [nbTooltipPlacement]="position"
           [nbTooltipAdjustment]="adjustment"
           [nbTooltipStatus]="status"
-          [nbTooltipIcon]="icon">
+          [nbTooltipIcon]="icon"
+          [nbTooltipClass]="tooltipClass">
         </button>
       </nb-layout-column>
     </nb-layout>
@@ -57,6 +59,7 @@ export class NbTooltipBindingsTestComponent {
   @Input() trigger = NbTrigger.CLICK;
   @Input() position = NbPosition.TOP;
   @Input() adjustment = NbAdjustment.CLOCKWISE;
+  tooltipClass = '';
 }
 
 @Component({
@@ -94,6 +97,7 @@ export class NbDynamicOverlayHandlerMock {
   _position: NbPosition = NbPosition.TOP;
   _adjustment: NbAdjustment = NbAdjustment.NOOP;
   _offset: number;
+  _overlayConfig: NbOverlayConfig = {};
 
   constructor() {
   }
@@ -135,6 +139,11 @@ export class NbDynamicOverlayHandlerMock {
 
   offset(offset: number) {
     this._offset = offset;
+    return this;
+  }
+
+  overlayConfig(overlayConfig: NbOverlayConfig) {
+    this._overlayConfig = overlayConfig;
     return this;
   }
 
@@ -472,6 +481,17 @@ describe('Directive: NbTooltipDirective', () => {
         fixture.detectChanges();
         expect(contentSpy).toHaveBeenCalledTimes(3);
         expect(contentSpy).toHaveBeenCalledWith('new string');
+      });
+
+      it('should set overlay config', () => {
+        const tooltipClass = 'custom-popover-class';
+        const overlayConfigSpy = spyOn(overlayHandler, 'overlayConfig').and.callThrough();
+
+        fixture = TestBed.createComponent(NbTooltipBindingsTestComponent);
+        fixture.componentInstance.tooltipClass = tooltipClass;
+        fixture.detectChanges();
+
+        expect(overlayConfigSpy).toHaveBeenCalledWith(jasmine.objectContaining({ panelClass: tooltipClass }));
       });
     });
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Adds `nbPopoverShowStateChange` output to the popover directive.
Also adds ability to use popover as a template variable:
```
<button nbPopover="..." #popover="nbPopover">...</button>

Is shown: {{ popover.isShown }}
```

Private popover directive properties changed to protected to simplify extension.

Add input for popover css class.

All above applies to tooltip as well.