### PR TITLE
fix(window): clear focus outline style on title of the window

### DIFF
--- a/src/framework/theme/components/window/window.component.scss
+++ b/src/framework/theme/components/window/window.component.scss
@@ -17,6 +17,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    outline: 0;
   }
   .buttons {
     width: 9.5rem;


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

On google chrome (version 79), when a window is opened, the browser set an outline default style at the title of the window, because this has an attribute `tabIndex=-1` for accessibility. So, i use css to clean that.
 
![image](https://user-images.githubusercontent.com/9917969/66515776-15129e80-eab6-11e9-8046-73f6678a0972.png)

