### PR TITLE
fix(datepicker): check trigger strategy is defined before destroying

### DIFF
--- a/src/framework/theme/components/datepicker/datepicker.component.ts
+++ b/src/framework/theme/components/datepicker/datepicker.component.ts
@@ -259,7 +259,9 @@ export abstract class NbBasePicker<D, T, P>
       this.ref.dispose();
     }
 
-    this.triggerStrategy.destroy();
+    if (this.triggerStrategy) {
+      this.triggerStrategy.destroy();
+    }
   }
 
   /**

--- a/src/framework/theme/components/datepicker/datepicker.spec.ts
+++ b/src/framework/theme/components/datepicker/datepicker.spec.ts
@@ -84,6 +84,11 @@ describe('nb-datepicker', () => {
     input = fixture.nativeElement.querySelector('input');
   });
 
+  it('should not throw when destroyed right after creation', () => {
+    const picker = TestBed.createComponent(NbDatepickerComponent).componentInstance;
+    expect(picker.ngOnDestroy.bind(picker)).not.toThrow();
+  });
+
   it('should render calendar', () => {
     showDatepicker();
     const calendar = overlay.querySelector('nb-calendar');


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Prevents the `DatePickerComponent` from crashing if it is destroyed shortly after its creation. View this issue for a more detailed description: https://github.com/akveo/nebular/issues/2007.

This error occurs without the null check:
![Capture2](https://user-images.githubusercontent.com/56301256/66391307-0ef4c300-e9cd-11e9-958a-b94395195c10.PNG)

