### PR TITLE
fix(datepicker, radio): always call touched callback

### DIFF
--- a/src/framework/theme/components/datepicker/datepicker.directive.ts
+++ b/src/framework/theme/components/datepicker/datepicker.directive.ts
@@ -462,10 +462,8 @@ export class NbDatepickerDirective<D> implements OnDestroy, ControlValueAccessor
       fromEvent(this.input, 'blur').pipe(
         filter(() => !this.picker.isShown && this.document.activeElement !== this.input),
       ),
-    ).pipe(
-      takeWhile(() => this.alive),
-      take(1),
-    ).subscribe(() => this.onTouched());
+    ).pipe(takeWhile(() => this.alive))
+     .subscribe(() => this.onTouched());
   }
 
   protected writePicker(value: D) {

--- a/src/framework/theme/components/radio/radio-group.component.ts
+++ b/src/framework/theme/components/radio/radio-group.component.ts
@@ -22,7 +22,7 @@ import {
 import { isPlatformBrowser } from '@angular/common';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { fromEvent, merge } from 'rxjs';
-import { filter, switchMap, take, takeUntil, takeWhile } from 'rxjs/operators';
+import { filter, switchMap, takeUntil, takeWhile } from 'rxjs/operators';
 import { convertToBoolProperty } from '../helpers';
 import { NB_DOCUMENT } from '../../theme.options';
 import { NbRadioComponent } from './radio.component';
@@ -81,7 +81,6 @@ import { NbComponentStatus } from '../component-status';
 export class NbRadioGroupComponent implements AfterContentInit, OnDestroy, ControlValueAccessor {
 
   protected alive: boolean = true;
-  protected isTouched: boolean = false;
   protected onChange = (value: any) => {};
   protected onTouched = () => {};
 
@@ -232,7 +231,7 @@ export class NbRadioGroupComponent implements AfterContentInit, OnDestroy, Contr
 
   protected subscribeOnRadiosBlur() {
     const hasNoRadios = !this.radios || !this.radios.length;
-    if (!isPlatformBrowser(this.platformId) || this.isTouched || hasNoRadios) {
+    if (!isPlatformBrowser(this.platformId) || hasNoRadios) {
       return;
     }
 
@@ -246,15 +245,9 @@ export class NbRadioGroupComponent implements AfterContentInit, OnDestroy, Contr
           fromEvent<Event>(this.document, 'click'),
         )),
         filter(event => !hostElement.contains(event.target as Node)),
-        take(1),
         takeUntil(this.radios.changes),
       )
-      .subscribe(() => this.markTouched());
-  }
-
-  protected markTouched() {
-    this.isTouched = true;
-    this.onTouched();
+      .subscribe(() => this.onTouched());
   }
 
   protected updateStatus() {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
We need to call touched callback on each blur event to run control update and validation as Angular Forms Api relies on it when configured to update on `blur`. 