### PR TITLE
fix(icon): null icon content rendered as text in MS Edge (#1962)

### DIFF
--- a/src/framework/theme/components/icon/icon.component.ts
+++ b/src/framework/theme/components/icon/icon.component.ts
@@ -216,6 +216,8 @@ export class NbIconComponent implements NbIconConfig, OnChanges, OnInit {
     const content = iconDefinition.icon.getContent(options);
     if (content) {
       this.html = this.sanitizer.bypassSecurityTrustHtml(content);
+    } else {
+      this.html = '';
     }
 
     this.assignClasses(iconDefinition.icon.getClasses(options));


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

This pull request aims to resolve #1962 with the code suggested by @yetanotherspinner on the linked issue.