### PR TITLE
 fix(auth): use basic status instead deprecated empty string

### DIFF
--- a/src/framework/auth/components/login/login.component.html
+++ b/src/framework/auth/components/login/login.component.html
@@ -29,7 +29,7 @@
            placeholder="Email address"
            fieldSize="large"
            autofocus
-           [status]="email.dirty ? (email.invalid  ? 'danger' : 'success') : ''"
+           [status]="email.dirty ? (email.invalid  ? 'danger' : 'success') : 'basic'"
            [required]="getConfigValue('forms.validation.email.required')"
            [attr.aria-invalid]="email.invalid && email.touched ? true : null">
     <ng-container *ngIf="email.invalid && email.touched">
@@ -56,7 +56,7 @@
            id="input-password"
            placeholder="Password"
            fieldSize="large"
-           [status]="password.dirty ? (password.invalid  ? 'danger' : 'success') : ''"
+           [status]="password.dirty ? (password.invalid  ? 'danger' : 'success') : 'basic'"
            [required]="getConfigValue('forms.validation.password.required')"
            [minlength]="getConfigValue('forms.validation.password.minLength')"
            [maxlength]="getConfigValue('forms.validation.password.maxLength')"

--- a/src/framework/auth/components/register/register.component.html
+++ b/src/framework/auth/components/register/register.component.html
@@ -27,7 +27,7 @@
            autofocus
            fullWidth
            fieldSize="large"
-           [status]="fullName.dirty ? (fullName.invalid  ? 'danger' : 'success') : ''"
+           [status]="fullName.dirty ? (fullName.invalid  ? 'danger' : 'success') : 'basic'"
            [required]="getConfigValue('forms.validation.fullName.required')"
            [minlength]="getConfigValue('forms.validation.fullName.minLength')"
            [maxlength]="getConfigValue('forms.validation.fullName.maxLength')"
@@ -56,7 +56,7 @@
            placeholder="Email address"
            fullWidth
            fieldSize="large"
-           [status]="email.dirty ? (email.invalid  ? 'danger' : 'success') : ''"
+           [status]="email.dirty ? (email.invalid  ? 'danger' : 'success') : 'basic'"
            [required]="getConfigValue('forms.validation.email.required')"
            [attr.aria-invalid]="email.invalid && email.touched ? true : null">
     <ng-container *ngIf="email.invalid && email.touched">
@@ -80,7 +80,7 @@
            placeholder="Password"
            fullWidth
            fieldSize="large"
-           [status]="password.dirty ? (password.invalid  ? 'danger' : 'success') : ''"
+           [status]="password.dirty ? (password.invalid  ? 'danger' : 'success') : 'basic'"
            [required]="getConfigValue('forms.validation.password.required')"
            [minlength]="getConfigValue('forms.validation.password.minLength')"
            [maxlength]="getConfigValue('forms.validation.password.maxLength')"
@@ -109,7 +109,7 @@
            placeholder="Confirm Password"
            fullWidth
            fieldSize="large"
-           [status]="rePass.dirty ? (rePass.invalid || password.value != rePass.value  ? 'danger' : 'success') : ''"
+           [status]="rePass.dirty ? (rePass.invalid || password.value != rePass.value  ? 'danger' : 'success') : 'basic'"
            [required]="getConfigValue('forms.validation.password.required')"
            [attr.aria-invalid]="rePass.invalid && rePass.touched ? true : null">
     <ng-container *ngIf="rePass.invalid && rePass.touched">

--- a/src/framework/auth/components/request-password/request-password.component.html
+++ b/src/framework/auth/components/request-password/request-password.component.html
@@ -29,7 +29,7 @@
            autofocus
            fullWidth
            fieldSize="large"
-           [status]="email.dirty ? (email.invalid  ? 'danger' : 'success') : ''"
+           [status]="email.dirty ? (email.invalid  ? 'danger' : 'success') : 'basic'"
            [required]="getConfigValue('forms.validation.email.required')"
            [attr.aria-invalid]="email.invalid && email.touched ? true : null">
     <ng-container *ngIf="email.invalid && email.touched">

--- a/src/framework/auth/components/reset-password/reset-password.component.html
+++ b/src/framework/auth/components/reset-password/reset-password.component.html
@@ -30,7 +30,7 @@
            autofocus
            fullWidth
            fieldSize="large"
-           [status]="password.dirty ? (password.invalid  ? 'danger' : 'success') : ''"
+           [status]="password.dirty ? (password.invalid  ? 'danger' : 'success') : 'basic'"
            [required]="getConfigValue('forms.validation.password.required')"
            [minlength]="getConfigValue('forms.validation.password.minLength')"
            [maxlength]="getConfigValue('forms.validation.password.maxLength')"

--- a/src/framework/auth/components/reset-password/reset-password.component.html
+++ b/src/framework/auth/components/reset-password/reset-password.component.html
@@ -62,7 +62,7 @@
            fieldSize="large"
            [status]="rePass.touched
                ? (rePass.invalid || password.value != rePass.value ? 'danger' : 'success')
-               : ''"
+               : 'basic'"
            [required]="getConfigValue('forms.validation.password.required')"
            [attr.aria-invalid]="rePass.invalid && rePass.touched ? true : null">
     <ng-container *ngIf="rePass.touched">


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [X] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

On Auth components with https://github.com/akveo/nebular/pull/2047/files# changes:
Warning message is triggered when nbInput component with status input attribute is an empty string.
On login component there is an occurrence with this issue. Replace empty string with `basic` value on status attribute. 