### PR TITLE
fix: provide Nebular scroll services adapters

### DIFF
--- a/src/framework/theme/components/cdk/adapter/adapter.module.ts
+++ b/src/framework/theme/components/cdk/adapter/adapter.module.ts
@@ -17,10 +17,12 @@ export class NbCdkAdapterModule {
         NbViewportRulerAdapter,
         NbOverlayContainerAdapter,
         NbBlockScrollStrategyAdapter,
+        NbScrollDispatcherAdapter,
+        NbScrollStrategyOptions,
         { provide: OverlayContainer, useExisting: NbOverlayContainerAdapter },
         { provide: NbOverlayContainer, useExisting: NbOverlayContainerAdapter },
-        { provide: ScrollDispatcher, useClass: NbScrollDispatcherAdapter },
-        { provide: ScrollStrategyOptions, useClass: NbScrollStrategyOptions },
+        { provide: ScrollDispatcher, useExisting: NbScrollDispatcherAdapter },
+        { provide: ScrollStrategyOptions, useExisting: NbScrollStrategyOptions },
       ],
     };
   }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
To be able explicitly specify Nebular class as injection token.