### PR TITLE
fix(route tabset): tab icon margin

### DIFF
--- a/src/framework/theme/components/route-tabset/route-tabset.component.scss
+++ b/src/framework/theme/components/route-tabset/route-tabset.component.scss
@@ -11,6 +11,7 @@
   flex-direction: row;
   list-style-type: none;
   margin: 0;
+  padding: 0;
 
   .route-tab {
     margin-bottom: -1px;

--- a/src/framework/theme/components/route-tabset/route-tabset.component.scss
+++ b/src/framework/theme/components/route-tabset/route-tabset.component.scss
@@ -50,6 +50,8 @@
   }
 }
 
-:host.full-width .route-tabset {
-  justify-content: space-around;
+:host(.full-width) {
+  .route-tabset {
+    justify-content: space-around;
+  }
 }

--- a/src/framework/theme/components/route-tabset/route-tabset.component.scss
+++ b/src/framework/theme/components/route-tabset/route-tabset.component.scss
@@ -38,12 +38,14 @@
       nb-icon {
         vertical-align: middle;
       }
-
-      nb-icon + span {
-        @include nb-ltr(margin-left, 0.5rem);
-        @include nb-rtl(margin-right, 0.5rem);
-      }
     }
+  }
+}
+
+:host {
+  .tab-link nb-icon + span {
+    @include nb-ltr(margin-left, 0.5rem);
+    @include nb-rtl(margin-right, 0.5rem);
   }
 }
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Moves `@include nb-ltr` and `@include nb-rtl` under `host` selector as required by mixin.
Also removes default `ul` padding.
And `:host.full-width` rewritten to correct form `:host(.full-width)`.