### PR TITLE
fix(button link): remove text decoration

### DIFF
--- a/src/framework/theme/components/button/_button.component.theme.scss
+++ b/src/framework/theme/components/button/_button.component.theme.scss
@@ -54,6 +54,10 @@
     }
   }
 
+  a[nbButton] {
+    text-decoration: none;
+  }
+
   @include button-filled;
   @include button-outline;
   @include button-ghost;

--- a/src/framework/theme/components/button/button.component.scss
+++ b/src/framework/theme/components/button/button.component.scss
@@ -9,7 +9,6 @@
 :host {
   appearance: none;
   text-align: center;
-  text-decoration: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Disables text decoration on button links. Setting `text-decoration` under `:host` selector isn't enough after #2169 as it adds `.nb-theme-<theme-name> a` selector which has more weight. Setting `text-decoration` in theme file fixes the problem.