### PR TITLE
fix(menu): prevent color override in css vars mode

### DIFF
--- a/src/framework/theme/components/menu/menu.component.scss
+++ b/src/framework/theme/components/menu/menu.component.scss
@@ -17,7 +17,6 @@
 
   .menu-item a {
     display: flex;
-    color: inherit;
     text-decoration: none;
     align-items: center;
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
:host color style overrides color set in theme file.