### PR TITLE
Added onMenuItemClicked in NbMenuItem

### DIFF
--- a/src/framework/theme/components/menu/menu.component.ts
+++ b/src/framework/theme/components/menu/menu.component.ts
@@ -88,6 +88,10 @@ export class NbMenuItemComponent implements DoCheck, AfterViewInit, OnDestroy {
   }
 
   onItemClick(item: NbMenuItem) {
+    if(item.onMenuItemClicked)
+    {
+      item.onMenuItemClicked();
+    }
     this.itemClick.emit(item);
   }
 

--- a/src/framework/theme/components/menu/menu.service.ts
+++ b/src/framework/theme/components/menu/menu.service.ts
@@ -102,6 +102,9 @@ export class NbMenuItem {
   data?: any;
   fragment?: string;
 
+  /**Menu Item Click Handler */
+  onMenuItemClicked?:Function;
+
   /**
    * @returns item parents in top-down order
    */


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
https://github.com/akveo/nebular/issues/1555

Added onMenuItemClicked function in NbMenuItem so that we can easily pass the click event handler to the menu item and process it in angular component.

e.g.
```
userMenu= [ 
    { 
       title: 'Profile',
       icon:'person-outline',
       onMenuItemClicked : this.ProfileClicked.bind(this) }, 
];

ProfileClicked()
{
    console.info("Profile clicked!");
    this.toastrService.info("Profile Clicked! Hurray!")
}
```
