### PR TITLE
refactor(auth): require valid token by default

### DIFF
--- a/src/framework/auth/strategies/oauth2/oauth2-strategy.options.ts
+++ b/src/framework/auth/strategies/oauth2/oauth2-strategy.options.ts
@@ -47,6 +47,7 @@ export class NbOAuth2AuthStrategyOptions extends NbAuthStrategyOptions {
   } = {
     endpoint: 'authorize',
     responseType: NbOAuth2ResponseType.CODE,
+    requireValidToken: true,
   };
   token?: {
     endpoint?: string;
@@ -58,7 +59,7 @@ export class NbOAuth2AuthStrategyOptions extends NbAuthStrategyOptions {
   } = {
     endpoint: 'token',
     grantType: NbOAuth2GrantType.AUTHORIZATION_CODE,
-    requireValidToken: false,
+    requireValidToken: true,
     class: NbAuthOAuth2Token,
   };
   refresh?: {
@@ -69,6 +70,7 @@ export class NbOAuth2AuthStrategyOptions extends NbAuthStrategyOptions {
   } = {
     endpoint: 'token',
     grantType: NbOAuth2GrantType.REFRESH_TOKEN,
+    requireValidToken: true,
   };
 }
 

--- a/src/framework/auth/strategies/oauth2/oauth2-strategy.ts
+++ b/src/framework/auth/strategies/oauth2/oauth2-strategy.ts
@@ -55,7 +55,7 @@ import { NbAuthStrategyClass } from '../../auth.options';
  *     endpoint?: string;
  *     redirectUri?: string;
  *     responseType?: string;
- *     requireValidToken: false,
+ *     requireValidToken: true,
  *     scope?: string;
  *     state?: string;
  *     params?: { [key: string]: string };
@@ -66,7 +66,7 @@ import { NbAuthStrategyClass } from '../../auth.options';
  *   token?: {
  *     endpoint?: string;
  *     grantType?: string;
- *     requireValidToken: false,
+ *     requireValidToken: true,
  *     redirectUri?: string;
  *     scope?: string;
  *     class: NbAuthTokenClass,
@@ -79,7 +79,7 @@ import { NbAuthStrategyClass } from '../../auth.options';
  *     endpoint?: string;
  *     grantType?: string;
  *     scope?: string;
- *     requireValidToken: false,
+ *     requireValidToken: true,
  *   } = {
  *     endpoint: 'token',
  *     grantType: NbOAuth2GrantType.REFRESH_TOKEN,

--- a/src/framework/auth/strategies/password/password-strategy-options.ts
+++ b/src/framework/auth/strategies/password/password-strategy-options.ts
@@ -43,7 +43,7 @@ export class NbPasswordAuthStrategyOptions extends NbAuthStrategyOptions {
     alwaysFail: false,
     endpoint: 'login',
     method: 'post',
-    requireValidToken: false,
+    requireValidToken: true,
     redirect: {
       success: '/',
       failure: null,
@@ -55,7 +55,7 @@ export class NbPasswordAuthStrategyOptions extends NbAuthStrategyOptions {
     alwaysFail: false,
     endpoint: 'register',
     method: 'post',
-    requireValidToken: false,
+    requireValidToken: true,
     redirect: {
       success: '/',
       failure: null,
@@ -98,7 +98,7 @@ export class NbPasswordAuthStrategyOptions extends NbAuthStrategyOptions {
   refreshToken?: boolean | NbPasswordStrategyModule = {
     endpoint: 'refresh-token',
     method: 'post',
-    requireValidToken: false,
+    requireValidToken: true,
     redirect: {
       success: null,
       failure: null,

--- a/src/framework/auth/strategies/password/password-strategy.ts
+++ b/src/framework/auth/strategies/password/password-strategy.ts
@@ -31,7 +31,7 @@ import { NbAuthIllegalTokenError } from '../../services/token/token';
  *    alwaysFail: false,
  *    endpoint: 'login',
  *    method: 'post',
- *    requireValidToken: false,
+ *    requireValidToken: true,
  *    redirect: {
  *      success: '/',
  *      failure: null,
@@ -43,7 +43,7 @@ import { NbAuthIllegalTokenError } from '../../services/token/token';
  *    alwaysFail: false,
  *    endpoint: 'register',
  *    method: 'post',
- *    requireValidToken: false,
+ *    requireValidToken: true,
  *    redirect: {
  *      success: '/',
  *      failure: null,
@@ -86,7 +86,7 @@ import { NbAuthIllegalTokenError } from '../../services/token/token';
  *  refreshToken?: boolean | NbPasswordStrategyModule = {
  *    endpoint: 'refresh-token',
  *    method: 'post',
- *    requireValidToken: false,
+ *    requireValidToken: true,
  *    redirect: {
  *      success: null,
  *      failure: null,

--- a/src/playground/without-layout/auth/auth.module.ts
+++ b/src/playground/without-layout/auth/auth.module.ts
@@ -89,9 +89,6 @@ export function filterInterceptorRequest(req: HttpRequest<any>) {
           token: {
             class: NbAuthJWTToken,
           },
-          login: {
-            requireValidToken: false,
-          },
           baseEndpoint: 'http://localhost:4400/api/auth/',
           logout: {
             redirect: {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Closes #1246.

BREAKING CHANGE:
`requireValidToken` set to true by default.
Now if response contains invalid token `NbAuthIllegalTokenError` is thrown.
To enable old behavior, set `requireValidToken: false` in the auth strategy method config, e.g.:
```
NbPasswordAuthStrategy.setup({
  // ...
  login: {
    // ...
    requireValidToken: false,
  },
});
```
or
```
NbOAuth2AuthStrategy.setup({
  // ...
  authorize: {
    // ...
    requireValidToken: false,
  },
});
```