### PR TITLE
Created conditional show minimize/maximize action buttons on window component

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -263,7 +263,11 @@
               "docs/favicon.ico",
               "docs/favicon.png",
               "docs/google46533d2e7a851062.html",
-              { "glob": "versions.json", "input": "docs/", "output": "/" }
+              {
+                "glob": "versions.json",
+                "input": "docs/",
+                "output": "/"
+              }
             ],
             "styles": [
               "node_modules/pace-js/templates/pace-theme-flash.tmpl.css",
@@ -326,8 +330,7 @@
             "karmaConfig": "./karma.conf.js",
             "polyfills": "docs/polyfills.ts",
             "tsConfig": "docs/tsconfig.spec.json",
-            "scripts": [
-            ],
+            "scripts": [],
             "styles": [
               "node_modules/highlight.js/styles/dracula.css",
               "docs/app/@theme/styles/styles.scss"
@@ -383,5 +386,8 @@
     "@schematics/angular:directive": {
       "prefix": "app"
     }
+  },
+  "cli": {
+    "analytics": "650ae037-17e3-4397-a8eb-7f542a78965d"
   }
 }

--- a/src/framework/theme/components/window/window.component.scss
+++ b/src/framework/theme/components/window/window.component.scss
@@ -27,6 +27,9 @@
       flex: 0 0 3rem;
     }
   }
+  .noActions{
+    justify-content: right;
+  }
 }
 
 :host(.full-screen) {

--- a/src/framework/theme/components/window/window.component.scss
+++ b/src/framework/theme/components/window/window.component.scss
@@ -27,7 +27,7 @@
       flex: 0 0 3rem;
     }
   }
-  .noActions{
+  .noActions {
     justify-content: right;
   }
 }

--- a/src/framework/theme/components/window/window.component.ts
+++ b/src/framework/theme/components/window/window.component.ts
@@ -26,7 +26,7 @@ import { NbWindowRef } from './window-ref';
       <nb-card-header>
         <div cdkFocusInitial class="title" tabindex="-1">{{ config.title }}</div>
 
-        <div class="buttons">
+        <div class="buttons" *ngIf="config.showActions">
           <button nbButton ghost (click)="minimize()">
             <nb-icon icon="minus-outline" pack="nebular-essentials"></nb-icon>
           </button>
@@ -40,6 +40,11 @@ import { NbWindowRef } from './window-ref';
             <nb-icon icon="close-outline" pack="nebular-essentials"></nb-icon>
           </button>
         </div>
+        <div class="buttons noActions" *ngIf="!config.showActions">
+        <button nbButton ghost (click)="close()">
+          <nb-icon icon="close-outline" pack="nebular-essentials"></nb-icon>
+        </button>
+      </div>
       </nb-card-header>
       <nb-card-body *ngIf="maximized || isFullScreen">
         <nb-overlay-container></nb-overlay-container>

--- a/src/framework/theme/components/window/window.options.ts
+++ b/src/framework/theme/components/window/window.options.ts
@@ -67,6 +67,11 @@ export class NbWindowConfig {
    */
   viewContainerRef: ViewContainerRef = null;
 
+  /**
+   * Defines if the minimize/maximize buttons are shown
+   */
+  showActions?: Boolean = true;
+
   constructor(...configs: Partial<NbWindowConfig>[]) {
     Object.assign(this, ...configs);
   }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Adds a new feature that show/hide action buttons (minimize/maximize) with the config option "showActions" of window component that can be configured when the component is used. By default, it works like before, and the added option is by default true, so can be changed to false whenever it is desired to work. Also, added the css class no actions, to correctly display the close button when the actions buttons are not shown.
This feature is added because i had the need of hide minimize/maximize buttons of a window component.
