### PR TITLE
AngularfireAuth doesn't have a signOut method.

### DIFF
--- a/src/framework/firebase-auth/strategies/base/firebase-base.strategy.ts
+++ b/src/framework/firebase-auth/strategies/base/firebase-base.strategy.ts
@@ -22,7 +22,7 @@ export abstract class NbFirebaseBaseStrategy extends NbAuthStrategy {
 
   logout(): Observable<NbAuthResult> {
     const module = 'logout';
-    return from(this.afAuth.signOut())
+    return from(this.afAuth.auth.signOut())
       .pipe(
         map(() => {
           return new NbAuthResult(


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

When I tried out the new FirebaseAuth Strategy I came accross this when I tried to logout. I changed it and it works currently for me.
