### PR TITLE
fix(dynamic overlay): prevent multiple onStable subscriptions

### DIFF
--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.spec.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.spec.ts
@@ -293,7 +293,7 @@ describe('dynamic-overlay', () => {
 
     expect(instance.content).toBe(newContent);
     expect(renderContentSpy).toHaveBeenCalledTimes(2);
-    expect(updatePositionSpy).toHaveBeenCalledTimes(1);
+    expect(updatePositionSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should set context when shown', () => {
@@ -307,7 +307,7 @@ describe('dynamic-overlay', () => {
 
     expect(instance.context).toBe(newContext);
     expect(renderContentSpy).toHaveBeenCalledTimes(2);
-    expect(updatePositionSpy).toHaveBeenCalledTimes(1);
+    expect(updatePositionSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should set context & content when shown', () => {
@@ -325,7 +325,7 @@ describe('dynamic-overlay', () => {
     expect(instance.context).toBe(newContext);
     expect(instance.content).toBe(newContent);
     expect(renderContentSpy).toHaveBeenCalledTimes(3);
-    expect(updatePositionSpy).toHaveBeenCalledTimes(2);
+    expect(updatePositionSpy).toHaveBeenCalledTimes(4);
   });
 
   it('should set component', () => {

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
@@ -229,7 +229,7 @@ export class NbDynamicOverlay {
     );
 
     this.zone.onStable
-      .pipe(takeUntil(merge([this.destroy$, overlayDestroy$])))
+      .pipe(takeUntil(merge(this.destroy$, overlayDestroy$)))
       .subscribe(() => this.updatePosition());
   }
 

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
@@ -33,6 +33,7 @@ export class NbDynamicOverlay {
   protected positionStrategyChange$ = new Subject();
   protected isShown$ = new BehaviorSubject<boolean>(false);
   protected destroy$ = new Subject<void>();
+  protected overlayDestroy$ = new Subject<NbOverlayRef>();
 
   get isAttached(): boolean {
     return this.ref && this.ref.hasAttached();
@@ -175,6 +176,7 @@ export class NbDynamicOverlay {
     this.disposeOverlayRef();
     this.isShown$.complete();
     this.positionStrategyChange$.complete();
+    this.overlayDestroy$.complete();
   }
 
   getContainer() {
@@ -187,7 +189,7 @@ export class NbDynamicOverlay {
       scrollStrategy: this.overlay.scrollStrategies.reposition(),
       ...this.overlayConfig,
     });
-    this.updatePositionWhenStable();
+    this.updatePositionWhenStable(this.ref);
   }
 
   protected renderContainer() {
@@ -218,9 +220,13 @@ export class NbDynamicOverlay {
    * Dimensions of the container may change after content update. So we listen to zone.stable event to
    * reposition the container.
    */
-  protected updatePositionWhenStable() {
+  protected updatePositionWhenStable(overlay: NbOverlayRef) {
+    const overlayDestroy$ = this.overlayDestroy$.pipe(
+      filter((destroyedOverlay: NbOverlayRef) => destroyedOverlay === overlay),
+    );
+
     this.zone.onStable
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntil(merge([this.destroy$, overlayDestroy$])))
       .subscribe(() => {
         this.ref && this.ref.updatePosition();
       });
@@ -233,6 +239,7 @@ export class NbDynamicOverlay {
   protected disposeOverlayRef() {
     if (this.ref) {
       this.ref.dispose();
+      this.overlayDestroy$.next(this.ref);
       this.ref = null;
       this.container = null;
     }

--- a/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
+++ b/src/framework/theme/components/cdk/overlay/dynamic/dynamic-overlay.ts
@@ -70,6 +70,7 @@ export class NbDynamicOverlay {
     if (this.container) {
       this.updateContext();
     }
+    this.updatePosition();
   }
 
   setContext(context: Object) {
@@ -78,6 +79,7 @@ export class NbDynamicOverlay {
     if (this.container) {
       this.updateContext();
     }
+    this.updatePosition();
   }
 
   setContentAndContext(content: NbOverlayContent, context: Object) {
@@ -86,6 +88,7 @@ export class NbDynamicOverlay {
     if (this.container) {
       this.updateContext();
     }
+    this.updatePosition();
   }
 
   setComponent(componentType: Type<NbRenderableContainer>) {
@@ -227,9 +230,13 @@ export class NbDynamicOverlay {
 
     this.zone.onStable
       .pipe(takeUntil(merge([this.destroy$, overlayDestroy$])))
-      .subscribe(() => {
-        this.ref && this.ref.updatePosition();
-      });
+      .subscribe(() => this.updatePosition());
+  }
+
+  protected updatePosition() {
+    if (this.ref) {
+      this.ref.updatePosition();
+    }
   }
 
   protected hasOverlayInContainer(): boolean {

--- a/src/framework/theme/components/context-menu/context-menu.directive.ts
+++ b/src/framework/theme/components/context-menu/context-menu.directive.ts
@@ -133,7 +133,16 @@ export class NbContextMenuDirective implements NbDynamicOverlayController, OnCha
    * Can be top, right, bottom and left.
    * */
   @Input('nbContextMenuPlacement')
-  position: NbPosition = NbPosition.BOTTOM;
+  get position(): NbPosition {
+    return this._position;
+  }
+  set position(value: NbPosition) {
+    if (value !== this.position) {
+      this._position = value;
+      this.updateOverlayContext();
+    }
+  }
+  _position: NbPosition = NbPosition.BOTTOM;
 
   /**
    * Container position will be changes automatically based on this strategy if container can't fit view port.
@@ -147,7 +156,16 @@ export class NbContextMenuDirective implements NbDynamicOverlayController, OnCha
    * Set NbMenu tag, which helps identify menu when working with NbMenuService.
    * */
   @Input('nbContextMenuTag')
-  tag: string;
+  get tag(): string {
+    return this._tag;
+  }
+  set tag(value: string) {
+    if (value !== this.tag) {
+      this._tag = value;
+      this.updateOverlayContext();
+    }
+  }
+  _tag: string;
 
   /**
    * Basic menu items, will be passed to the internal NbMenuComponent.
@@ -159,6 +177,7 @@ export class NbContextMenuDirective implements NbDynamicOverlayController, OnCha
   set items(items: NbMenuItem[]) {
     this.validateItems(items);
     this._items = items;
+    this.updateOverlayContext();
   };
 
   /**
@@ -170,7 +189,16 @@ export class NbContextMenuDirective implements NbDynamicOverlayController, OnCha
   static ngAcceptInputType_trigger: NbTriggerValues;
 
   @Input('nbContextMenuClass')
-  contextMenuClass: string = '';
+  get contextMenuClass(): string {
+    return this._contextMenuClass;
+  }
+  set contextMenuClass(value: string) {
+    if (value !== this.contextMenuClass) {
+      this._contextMenuClass = value;
+      this.overlayConfig = { panelClass: this.contextMenuClass };
+    }
+  }
+  _contextMenuClass: string = '';
 
   protected ref: NbOverlayRef;
   protected container: ComponentRef<any>;
@@ -193,15 +221,7 @@ export class NbContextMenuDirective implements NbDynamicOverlayController, OnCha
       .componentType(NbContextMenuComponent);
   }
 
-  ngOnChanges({ contextMenuClass, items, position, tag }: SimpleChanges) {
-    if (contextMenuClass) {
-      this.overlayConfig = { panelClass: this.contextMenuClass };
-    }
-
-    if (items || position || tag) {
-      this.overlayContext = { items: this.items, position: this.position, tag: this.tag };
-    }
-
+  ngOnChanges() {
     this.rebuild();
   }
 
@@ -258,5 +278,9 @@ export class NbContextMenuDirective implements NbDynamicOverlayController, OnCha
         takeUntil(this.destroy$),
       )
       .subscribe(() => this.hide());
+  }
+
+  protected updateOverlayContext() {
+    this.overlayContext = { items: this.items, position: this.position, tag: this.tag };
   }
 }

--- a/src/framework/theme/components/popover/popover.directive.ts
+++ b/src/framework/theme/components/popover/popover.directive.ts
@@ -14,6 +14,7 @@ import {
   OnInit,
   Output,
   EventEmitter,
+  SimpleChanges,
 } from '@angular/core';
 
 import { NbDynamicOverlay, NbDynamicOverlayController } from '../cdk/overlay/dynamic/dynamic-overlay';
@@ -21,6 +22,7 @@ import { NbDynamicOverlayHandler } from '../cdk/overlay/dynamic/dynamic-overlay-
 import { NbAdjustment, NbPosition, NbPositionValues, NbAdjustmentValues } from '../cdk/overlay/overlay-position';
 import { NbOverlayContent } from '../cdk/overlay/overlay-service';
 import { NbTrigger, NbTriggerValues } from '../cdk/overlay/overlay-trigger';
+import { NbOverlayConfig } from '../cdk/overlay/mapping';
 import { NbPopoverComponent } from './popover.component';
 import { takeUntil, skip } from 'rxjs/operators';
 import { Subject } from 'rxjs';
@@ -183,6 +185,8 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
   @Output()
   nbPopoverShowStateChange = new EventEmitter<{ isShown: boolean }>();
 
+  protected overlayConfig: NbOverlayConfig = { panelClass: this.popoverClass }
+
   get isShown(): boolean {
     return !!(this.dynamicOverlay && this.dynamicOverlay.isAttached);
   }
@@ -197,7 +201,11 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
       .componentType(this.popoverComponent);
   }
 
-  ngOnChanges() {
+  ngOnChanges({ popoverClass }: SimpleChanges) {
+    if (popoverClass) {
+      this.overlayConfig = { panelClass: this.popoverClass };
+    }
+
     this.rebuild();
   }
 
@@ -244,6 +252,6 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
       .adjustment(this.adjustment)
       .content(this.content)
       .context(this.context)
-      .overlayConfig({ panelClass: this.popoverClass });
+      .overlayConfig(this.overlayConfig);
   }
 }

--- a/src/framework/theme/components/popover/popover.directive.ts
+++ b/src/framework/theme/components/popover/popover.directive.ts
@@ -180,7 +180,16 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
   offset = 15;
 
   @Input('nbPopoverClass')
-  popoverClass: string = '';
+  get popoverClass(): string {
+    return this._popoverClass;
+  }
+  set popoverClass(value: string) {
+    if (value !== this.popoverClass) {
+      this._popoverClass = value;
+      this.overlayConfig = { panelClass: this.popoverClass };
+    }
+  }
+  _popoverClass: string = '';
 
   @Output()
   nbPopoverShowStateChange = new EventEmitter<{ isShown: boolean }>();
@@ -201,11 +210,7 @@ export class NbPopoverDirective implements NbDynamicOverlayController, OnChanges
       .componentType(this.popoverComponent);
   }
 
-  ngOnChanges({ popoverClass }: SimpleChanges) {
-    if (popoverClass) {
-      this.overlayConfig = { panelClass: this.popoverClass };
-    }
-
+  ngOnChanges() {
     this.rebuild();
   }
 

--- a/src/framework/theme/components/tooltip/tooltip.directive.ts
+++ b/src/framework/theme/components/tooltip/tooltip.directive.ts
@@ -116,7 +116,16 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
   static ngAcceptInputType_adjustment: NbAdjustmentValues;
 
   @Input('nbTooltipClass')
-  tooltipClass: string = '';
+  get tooltipClass(): string {
+    return this._tooltipClass;
+  }
+  set tooltipClass(value: string) {
+    if (value !== this.tooltipClass) {
+      this._tooltipClass = value;
+      this.overlayConfig = { panelClass: this.tooltipClass };
+    }
+  }
+  _tooltipClass: string = '';
 
   /**
    * Accepts icon name or icon config object
@@ -163,11 +172,7 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
       .offset(this.offset);
   }
 
-  ngOnChanges({ tooltipClass }: SimpleChanges) {
-    if (tooltipClass) {
-      this.overlayConfig = { panelClass: this.tooltipClass };
-    }
-
+  ngOnChanges() {
     this.rebuild();
   }
 

--- a/src/framework/theme/components/tooltip/tooltip.directive.ts
+++ b/src/framework/theme/components/tooltip/tooltip.directive.ts
@@ -14,6 +14,7 @@ import {
   OnInit,
   Output,
   EventEmitter,
+  SimpleChanges,
 } from '@angular/core';
 import { skip, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
@@ -23,6 +24,7 @@ import { NbAdjustment, NbPosition, NbPositionValues, NbAdjustmentValues } from '
 import { NbTrigger } from '../cdk/overlay/overlay-trigger';
 import { NbDynamicOverlay } from '../cdk/overlay/dynamic/dynamic-overlay';
 import { NbDynamicOverlayHandler } from '../cdk/overlay/dynamic/dynamic-overlay-handler';
+import { NbOverlayConfig } from '../cdk/overlay/mapping';
 import { NbTooltipComponent } from './tooltip.component';
 import { NbIconConfig } from '../icon/icon.component';
 
@@ -144,6 +146,8 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
   @Output()
   nbTooltipShowStateChange = new EventEmitter<{ isShown: boolean }>();
 
+  protected overlayConfig: NbOverlayConfig = { panelClass: this.tooltipClass };
+
   get isShown(): boolean {
     return !!(this.dynamicOverlay && this.dynamicOverlay.isAttached);
   }
@@ -159,7 +163,11 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
       .offset(this.offset);
   }
 
-  ngOnChanges() {
+  ngOnChanges({ tooltipClass }: SimpleChanges) {
+    if (tooltipClass) {
+      this.overlayConfig = { panelClass: this.tooltipClass };
+    }
+
     this.rebuild();
   }
 
@@ -205,6 +213,6 @@ export class NbTooltipDirective implements OnInit, OnChanges, AfterViewInit, OnD
       .adjustment(this.adjustment)
       .content(this.content)
       .context(this.context)
-      .overlayConfig({ panelClass: this.tooltipClass });
+      .overlayConfig(this.overlayConfig);
   }
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
The main fix is 419ca7c. After the change, dynamic overlay unsubscribes from `zone.onStable` once overlay got destroyed. Before, every time the `show` method was called, we were creating an additional subscription, which leads to multiple `updatePosition` calls.

Changes from 3379373 is an additional fix, which ensures dynamic overlay context and config properties updating only once some property actually changed. Before, because of we were passing a new object to `overlayConfig` and `context` methods overlay was recreated on every `ngOnChanges` run. See commit description for details. UPD: 1763905 is a refactor of the way overlay config objects updated. First I decided to use change object from `OnChanges` hook, but we have tests which check if direct manipulation of component instance properties (not in the template) is also picked up. `OnChanges` hook doesn't track such changes, so I moved overlay config objects update code to the setters. This way you can change properties from anywhere (from template or component instance properties) and it'll work anyway.

The third commit 1840a9d, has an additional small fix. We need to call `updatePosition` once overlay content change, as it could affect overlay dimensions. It worked fine before because of the bug fixed in this PR.