### PR TITLE
fix(accordion): extract inner elements styles outside accordion

### DIFF
--- a/src/framework/theme/components/accordion/_accordion.component.theme.scss
+++ b/src/framework/theme/components/accordion/_accordion.component.theme.scss
@@ -24,56 +24,57 @@
     display: block;
     box-shadow: nb-theme(accordion-shadow);
     border-radius: nb-theme(accordion-border-radius);
+  }
 
-    nb-accordion-item-header {
-      position: relative;
-      @include nb-accordion-item-header();
+  nb-accordion-item-header {
+    position: relative;
+    @include nb-accordion-item-header();
 
-      .expansion-indicator {
-        position: absolute;
-        @include nb-ltr(right, 1rem);
-        @include nb-rtl(left, 1rem);
-      }
+    .expansion-indicator {
+      position: absolute;
+      @include nb-ltr(right, 1rem);
+      @include nb-rtl(left, 1rem);
+    }
+  }
+
+  nb-accordion-item {
+    background-color: nb-theme(accordion-item-background-color);
+    color: nb-theme(accordion-item-text-color);
+    font-family: nb-theme(accordion-item-text-font-family);
+    font-size: nb-theme(accordion-item-text-font-size);
+    font-weight: nb-theme(accordion-item-text-font-weight);
+    line-height: nb-theme(accordion-item-text-line-height);
+
+    &.disabled nb-accordion-item-header {
+      color: nb-theme(accordion-header-disabled-text-color);
+      cursor: default;
     }
 
-    nb-accordion-item {
-      background-color: nb-theme(accordion-item-background-color);
-      color: nb-theme(accordion-item-text-color);
-      font-family: nb-theme(accordion-item-text-font-family);
-      font-size: nb-theme(accordion-item-text-font-size);
-      font-weight: nb-theme(accordion-item-text-font-weight);
-      line-height: nb-theme(accordion-item-text-line-height);
+    &:first-child {
+      border-top-left-radius: nb-theme(accordion-border-radius);
+      border-top-right-radius: nb-theme(accordion-border-radius);
+    }
+    &:last-child {
+      border-bottom-left-radius: nb-theme(accordion-border-radius);
+      border-bottom-right-radius: nb-theme(accordion-border-radius);
 
-      &.disabled nb-accordion-item-header {
-        color: nb-theme(accordion-header-disabled-text-color);
-        cursor: default;
-      }
-
-      &:first-child {
-        border-top-left-radius: nb-theme(accordion-border-radius);
-        border-top-right-radius: nb-theme(accordion-border-radius);
-      }
-      &:last-child {
-        border-bottom-left-radius: nb-theme(accordion-border-radius);
-        border-bottom-right-radius: nb-theme(accordion-border-radius);
-
-        &.collapsed nb-accordion-item-header {
-          border-bottom: none;
-        }
+      &.collapsed nb-accordion-item-header {
+        border-bottom: none;
       }
     }
-    nb-accordion-item:not(.collapsed) + nb-accordion-item nb-accordion-item-header {
-      border-top-color: nb-theme(accordion-header-border-color);
-      border-top-style: nb-theme(accordion-header-border-style);
-      border-top-width: nb-theme(accordion-header-border-width);
-    }
+  }
 
-    nb-accordion-item-body .item-body {
-      flex: 1;
-      -ms-flex: 1 1 auto;
-      overflow: auto;
-      padding: nb-theme(accordion-padding);
-      position: relative;
-    }
+  nb-accordion-item:not(.collapsed) + nb-accordion-item nb-accordion-item-header {
+    border-top-color: nb-theme(accordion-header-border-color);
+    border-top-style: nb-theme(accordion-header-border-style);
+    border-top-width: nb-theme(accordion-header-border-width);
+  }
+
+  nb-accordion-item-body .item-body {
+    flex: 1;
+    -ms-flex: 1 1 auto;
+    overflow: auto;
+    padding: nb-theme(accordion-padding);
+    position: relative;
   }
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
This way `nb-accordion` inner items (like `nb-accordion-item-header`, `nb-accordion-item`, `nb-accordion-item-body`) keep their styles when are placed outside `nb-accordion` element (for example, when used as `cdkDrag` as when element dragged it placed in the body).