### PR TITLE
fix(calendar range cells): handle unset date or selectedValue

### DIFF
--- a/src/framework/theme/components/calendar-kit/components/calendar-day-picker/calendar-day-picker.component.ts
+++ b/src/framework/theme/components/calendar-kit/components/calendar-day-picker/calendar-day-picker.component.ts
@@ -141,8 +141,8 @@ export class NbCalendarDayPickerComponent<D, T> implements OnChanges {
   constructor(private monthModel: NbCalendarMonthModelService<D>) {
   }
 
-  ngOnChanges({ visibleDate }: SimpleChanges) {
-    if (visibleDate) {
+  ngOnChanges({ visibleDate, boundingMonths }: SimpleChanges) {
+    if (visibleDate || boundingMonths) {
       this.weeks = this.monthModel.createDaysGrid(this.visibleDate, this.boundingMonths);
     }
   }

--- a/src/framework/theme/components/calendar/calendar-range-day-cell.component.ts
+++ b/src/framework/theme/components/calendar/calendar-range-day-cell.component.ts
@@ -91,7 +91,7 @@ export class NbCalendarRangeDayCellComponent<D> extends NbBaseCalendarRangeCell<
     }
 
     if (this.selectedValue) {
-      return this.dateService.isSameDay(this.date, this.selectedValue.start);
+      return this.dateService.isSameDaySafe(this.date, this.selectedValue.start);
     }
   }
 

--- a/src/framework/theme/components/calendar/calendar-range-month-cell.component.ts
+++ b/src/framework/theme/components/calendar/calendar-range-month-cell.component.ts
@@ -60,7 +60,7 @@ export class NbCalendarRangeMonthCellComponent<D> extends NbBaseCalendarRangeCel
     }
 
     if (this.selectedValue) {
-      return this.dateService.isSameMonth(this.date, this.selectedValue.start);
+      return this.dateService.isSameMonthSafe(this.date, this.selectedValue.start);
     }
   }
 

--- a/src/framework/theme/components/calendar/calendar-range-year-cell.component.ts
+++ b/src/framework/theme/components/calendar/calendar-range-year-cell.component.ts
@@ -69,7 +69,7 @@ export class NbCalendarRangeYearCellComponent<D> extends NbBaseCalendarRangeCell
     }
 
     if (this.selectedValue) {
-      return this.dateService.isSameYear(this.date, this.selectedValue.start);
+      return this.dateService.isSameYearSafe(this.date, this.selectedValue.start);
     }
   }
 

--- a/src/framework/theme/components/datepicker/datepicker.component.ts
+++ b/src/framework/theme/components/datepicker/datepicker.component.ts
@@ -286,6 +286,7 @@ export abstract class NbBasePicker<D, T, P> extends NbDatepicker<T> {
     this.subscribeOnValueChange();
     this.writeQueue();
     this.patchWithInputs();
+    this.pickerRef.changeDetectorRef.markForCheck();
   }
 
   protected createPositionStrategy(): NbAdjustableConnectedPositionStrategy {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
d0850d4 is the main fix to handle `null`s in `date` and `selecteValue` properties. `date` could be null because of `[boundingMonth]="false"`, see commit description for details.
f5e2a82 and ad6442f are companion fixes for the issues I noticed when I was fixing the main issue.
f5e2a82 - input changes won't be picked up when the picker opens. See the commit description for details.
ad6442f - because `boundingMonth` property value affects bounding month `date` property, day picker should regenerate `weeks` when property change. See the commit description for details.