### PR TITLE
added support for other languages for user component 

### DIFF
--- a/src/framework/theme/components/user/user.component.ts
+++ b/src/framework/theme/components/user/user.component.ts
@@ -18,7 +18,7 @@ import { NbBadgePosition } from '../badge/badge.component';
  * @stacked-example(Showcase, user/user-showcase.component)
  *
  * ```ts
- *   <nb-user name="John Doe" title="Engineer"></nb-user>
+ *   <nb-user name='John Doe' title='Engineer'></nb-user>
  * ```
  *
  * ### Installation
@@ -113,7 +113,6 @@ import { NbBadgePosition } from '../badge/badge.component';
   templateUrl: './user.component.html',
 })
 export class NbUserComponent {
-
   imageBackgroundStyle: SafeStyle;
 
   /**
@@ -135,7 +134,9 @@ export class NbUserComponent {
    */
   @Input()
   set picture(value: string) {
-    this.imageBackgroundStyle = value ? this.domSanitizer.bypassSecurityTrustStyle(`url(${value})`) : null;
+    this.imageBackgroundStyle = value
+      ? this.domSanitizer.bypassSecurityTrustStyle(`url(${value})`)
+      : null;
   }
 
   /**
@@ -272,15 +273,32 @@ export class NbUserComponent {
     return this.shape === 'round';
   }
 
-  constructor(private domSanitizer: DomSanitizer) { }
+  constructor(private domSanitizer: DomSanitizer) {}
 
   getInitials(): string {
     if (this.name) {
       const names = this.name.split(' ');
-
-      return names.map(n => n.charAt(0)).splice(0, 2).join('').toUpperCase();
+      if (this.isLatin(this.name)) {
+        return names
+          .map((n) => n.charAt(0))
+          .splice(0, 2)
+          .join('')
+          .toUpperCase();
+      } else {
+        return names
+          .map((n) => n.charAt(0))
+          .splice(0, 2)
+          .join(' ')
+          .toUpperCase();
+      }
     }
 
     return '';
+  }
+
+  isLatin(text) {
+    const regex = /[a-za-zA-Z]/;
+    const result = regex.test(text);
+    return result;
   }
 }

--- a/src/playground/with-layout/list/users-list-showcase.component.ts
+++ b/src/playground/with-layout/list/users-list-showcase.component.ts
@@ -15,7 +15,7 @@ import { Component } from '@angular/core';
 })
 export class UsersListShowcaseComponent {
   users: { name: string, title: string }[] = [
-    { name: 'Carla Espinosa', title: 'Nurse' },
+    { name: 'مهدي حسني', title: 'Nurse' },
     { name: 'Bob Kelso', title: 'Doctor of Medicine' },
     { name: 'Janitor', title: 'Janitor' },
     { name: 'Perry Cox', title: 'Doctor of Medicine' },


### PR DESCRIPTION
hello, when passing a nonlatin characters name to the user component, it doesn't show up correctly for example for Arabic: 
![image](https://user-images.githubusercontent.com/19789975/95003131-d41f6e00-05d3-11eb-9ff3-18b0f369adc0.png)
it should be like this :
/home/talel/Pictures/arabic.png
the initials should be separated and not connected 