### PR TITLE
fix(toggle): alignment of toggle switches

### DIFF
--- a/src/framework/theme/components/toggle/_toggle.component.theme.scss
+++ b/src/framework/theme/components/toggle/_toggle.component.theme.scss
@@ -18,14 +18,12 @@
         We need to set initial positions as Angular animations won't work in IE11 if positions have no initial value.
         Setting it in SCSS as we don't have access to theme variables from TS.
       */
-
-      $switcher-vertical-offset: (#{nb-theme(toggle-height)} - #{nb-theme(toggle-switcher-size)}) / 2;
       @include nb-ltr() {
         &.checked .toggle-switcher {
           left: calc(100%
                      - #{nb-theme(toggle-switcher-size)}
                      - #{nb-theme(toggle-border-width)}
-                     - #{$switcher-vertical-offset});
+                     - #{nb-theme(toggle-border-width)});
         }
 
         &:not(.checked) .toggle-switcher {
@@ -38,7 +36,7 @@
           right: calc(100%
                       - #{nb-theme(toggle-switcher-size)}
                       - #{nb-theme(toggle-border-width)}
-                      - #{$switcher-vertical-offset});
+                      - #{nb-theme(toggle-border-width)});
         }
 
         &:not(.checked) .toggle-switcher {

--- a/src/framework/theme/components/toggle/_toggle.component.theme.scss
+++ b/src/framework/theme/components/toggle/_toggle.component.theme.scss
@@ -19,7 +19,7 @@
         Setting it in SCSS as we don't have access to theme variables from TS.
       */
 
-      $switcher-vertical-offset: (nb-theme(toggle-height) - nb-theme(toggle-switcher-size)) / 2;
+      $switcher-vertical-offset: (#{nb-theme(toggle-height)} - #{nb-theme(toggle-switcher-size)}) / 2;
       @include nb-ltr() {
         &.checked .toggle-switcher {
           left: calc(100%


### PR DESCRIPTION
Use SASS interpolation to compile value properly within CSS `calc` function

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Closes https://github.com/akveo/nebular/issues/2293