### PR TITLE
fix: pass mandatory 'document' object to viewportadapter constructor

### DIFF
--- a/src/framework/theme/components/cdk/adapter/viewport-ruler-adapter.ts
+++ b/src/framework/theme/components/cdk/adapter/viewport-ruler-adapter.ts
@@ -10,9 +10,9 @@ import { NbLayoutScrollService, NbScrollPosition } from '../../../services/scrol
 @Injectable()
 export class NbViewportRulerAdapter extends ViewportRuler {
   constructor(platform: NbPlatform, ngZone: NgZone,
-              protected ruler: NbLayoutRulerService,
-              protected scroll: NbLayoutScrollService) {
-    super(platform, ngZone);
+    protected ruler: NbLayoutRulerService,
+    protected scroll: NbLayoutScrollService) {
+    super(platform, ngZone, document);
   }
 
   getViewportSize(): Readonly<{ width: number; height: number; }> {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

In Angular 11, ViewPortRuler class made the parameter 'document' mandatory. If not passed, the NbViewportRulerAdapter will give an error and the app won't load.

More details in https://github.com/akveo/nebular/issues/2572
