### PR TITLE
feat(checkbox): remove deprecated value input

### DIFF
--- a/src/framework/theme/components/checkbox/checkbox.component.ts
+++ b/src/framework/theme/components/checkbox/checkbox.component.ts
@@ -283,25 +283,6 @@ export class NbCheckboxComponent implements AfterViewInit, ControlValueAccessor 
   onChange: any = () => { };
   onTouched: any = () => { };
 
-  /**
-   * Checkbox value
-   * @deprecated
-   * @breaking-change Remove @5.0.0
-   */
-  @Input()
-  get value(): boolean {
-    return this.checked;
-  }
-
-  /**
-   * @deprecated
-   * @breaking-change Remove @5.0.0
-   */
-  set value(value: boolean) {
-    console.warn('NbCheckbox: `value` is deprecated and will be removed in 5.0.0. Use `checked` instead.');
-    this.checked = value;
-  }
-
   @Input()
   get checked(): boolean {
     return this._checked;
@@ -355,21 +336,6 @@ export class NbCheckboxComponent implements AfterViewInit, ControlValueAccessor 
   }
   private _indeterminate: boolean = false;
   static ngAcceptInputType_indeterminate: NbBooleanInput;
-
-  /**
-   * Output when checked state is changed by a user
-   * @deprecated
-   * @breaking-change Remove @5.0.0
-   * @type EventEmitter<boolean>
-   */
-  @Output()
-  get valueChange(): EventEmitter<boolean> {
-    console.warn('NbCheckbox: `valueChange` is deprecated and will be removed in 5.0.0. Use `checkedChange` instead.');
-    return this.checkedChange;
-  }
-  set valueChange(valueChange: EventEmitter<boolean>) {
-    this.checkedChange = valueChange;
-  }
 
   /**
    * Output when checked state is changed by a user

--- a/src/framework/theme/components/checkbox/checkbox.spec.ts
+++ b/src/framework/theme/components/checkbox/checkbox.spec.ts
@@ -40,18 +40,6 @@ describe('Component: NbCheckbox', () => {
     expect(checkboxInput.nativeElement.disabled).toBeFalsy();
   });
 
-  it('Setting deprecated value to true makes checkbox input checked', () => {
-    checkbox.value = true;
-    fixture.detectChanges();
-    expect(checkboxInput.nativeElement.checked).toBeTruthy();
-  });
-
-  it('Setting deprecated value to false makes checkbox input unchecked', () => {
-    checkbox.value = false;
-    fixture.detectChanges();
-    expect(checkboxInput.nativeElement.checked).toBeFalsy();
-  });
-
   it('Setting checked to true makes checkbox input checked', () => {
     checkbox.checked = true;
     fixture.detectChanges();
@@ -92,31 +80,6 @@ describe('Component: NbCheckbox', () => {
     checkbox.status = 'info';
     fixture.detectChanges();
     expect(testContainerEl.classList.contains('status-info')).toBeTruthy();
-  });
-
-  it('deprecated should not emit change event when input changed', () => {
-
-    const spy = jasmine.createSpy('valueChange subscriber');
-
-    checkbox.valueChange
-      .subscribe(spy);
-
-    checkbox.checked = true;
-    fixture.detectChanges();
-    expect(spy).toHaveBeenCalledTimes(0);
-  });
-
-  it('deprecated  should emit change event when clicked', () => {
-
-    const spy = jasmine.createSpy('valueChange subscriber');
-
-    checkbox.valueChange
-      .subscribe(spy);
-
-    label.nativeElement.click();
-
-    fixture.detectChanges();
-    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('should not emit change event when input changed', () => {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
BREAKING CHANGE:
`NbCheckboxComponent.value` and `NbCheckboxComponent.valueChange` properties removed. Use `checked` and `checkedChange` accordingly.