### PR TITLE
feat(toastr): remove deprecated iconPack property

### DIFF
--- a/src/framework/theme/components/toastr/toast.component.html
+++ b/src/framework/theme/components/toastr/toast.component.html
@@ -1,5 +1,5 @@
 <div class="icon-container" *ngIf="hasIcon && icon">
-  <nb-icon [config]="iconConfig"></nb-icon>
+  <nb-icon [config]="icon"></nb-icon>
 </div>
 <div class="content-container">
   <span class="title subtitle">{{ toast.title }}</span>

--- a/src/framework/theme/components/toastr/toast.component.ts
+++ b/src/framework/theme/components/toastr/toast.component.ts
@@ -157,31 +157,6 @@ export class NbToastComponent implements OnInit {
     return this.toast.config.icon;
   }
 
-  /* @deprecated Use pack property of icon config */
-  get iconPack(): string {
-    return this.toast.config.iconPack;
-  }
-
-  /*
-    @breaking-change 5 remove
-    @deprecated
-  */
-  get iconConfig(): NbIconConfig {
-    const toastConfig = this.toast.config;
-    const isIconName = typeof this.icon === 'string';
-
-    if (!isIconName) {
-      return toastConfig.icon as NbIconConfig;
-    }
-
-    const iconConfig: NbIconConfig = { icon: toastConfig.icon as string };
-    if (toastConfig.iconPack) {
-      iconConfig.pack = toastConfig.iconPack;
-    }
-
-    return iconConfig;
-  }
-
   @HostListener('click')
   onClick() {
     this.destroy.emit();

--- a/src/framework/theme/components/toastr/toastr-config.ts
+++ b/src/framework/theme/components/toastr/toastr-config.ts
@@ -66,12 +66,6 @@ export class NbToastrConfig {
    * */
   icon: string | NbIconConfig = 'email';
   /**
-   * Icon pack to look for the icon in.
-   * @deprecated Set pack via icon config object passed to icon property
-   * @breaking-change 5.0.0
-   * */
-  iconPack: string;
-  /**
    * Toast status icon-class mapping.
    * */
   protected icons: IconToClassMap = {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
BREAKING CHANGE:
`NbToastrConfig.iconPack` property remove. You can set icon pack via `icon` property:
```
const toastrConfig = {
  // ...
  icon: { icon: 'star', pack: 'eva' },
}
```

`NbToastComponent.iconPack` and `NbToastComponent.iconConfig` properties removed.
Use `icon` property instead.