### PR TITLE
fix(sidebar): update state when responsive setting change

### DIFF
--- a/src/framework/theme/components/sidebar/sidebar.component.ts
+++ b/src/framework/theme/components/sidebar/sidebar.component.ts
@@ -462,7 +462,7 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
           this.collapse();
           newResponsiveState = 'mobile';
         }
-        if (!isCollapsed && !isCompacted && prev.width < current.width) {
+        if (!isCollapsed && !isCompacted && (!prev.width || prev.width < current.width)) {
           this.expand();
           this.fixed = false;
           newResponsiveState = 'pc';

--- a/src/framework/theme/components/sidebar/sidebar.component.ts
+++ b/src/framework/theme/components/sidebar/sidebar.component.ts
@@ -255,7 +255,7 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
   set state(value: NbSidebarState) {
     this._state = value;
   }
-  protected _state: NbSidebarState;
+  protected _state: NbSidebarState = 'expanded';
 
   /**
    * Makes sidebar listen to media query events and change its behaviour

--- a/src/framework/theme/components/sidebar/sidebar.component.ts
+++ b/src/framework/theme/components/sidebar/sidebar.component.ts
@@ -376,18 +376,14 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
    * Collapses the sidebar
    */
   collapse() {
-    this.state = 'collapsed';
-    this.stateChange.emit(this.state);
-    this.cd.markForCheck();
+    this.updateState('collapsed');
   }
 
   /**
    * Expands the sidebar
    */
   expand() {
-    this.state = 'expanded';
-    this.stateChange.emit(this.state);
-    this.cd.markForCheck();
+    this.updateState('expanded');
   }
 
   /**
@@ -418,12 +414,10 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
     }
 
     if (this.state === 'compacted' || this.state === 'collapsed') {
-      this.state = 'expanded';
+      this.updateState('expanded');
     } else {
-      this.state = compact ? 'compacted' : 'collapsed';
+      this.updateState(compact ? 'compacted' : 'collapsed');
     }
-    this.stateChange.emit(this.state);
-    this.cd.markForCheck();
   }
 
   protected subscribeToMediaQueryChange() {
@@ -473,6 +467,14 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
     }
 
     return this.getMenuLink(element.parentElement);
+  }
+
+  protected updateState(state: NbSidebarState): void {
+    if (this.state !== state) {
+      this.state = state;
+      this.stateChange.emit(this.state);
+      this.cd.markForCheck();
+    }
   }
 
   /**

--- a/src/framework/theme/components/sidebar/sidebar.component.ts
+++ b/src/framework/theme/components/sidebar/sidebar.component.ts
@@ -407,9 +407,7 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
    * Compacts the sidebar (minimizes)
    */
   compact() {
-    this.state = 'compacted';
-    this.stateChange.emit(this.state);
-    this.cd.markForCheck();
+    this.updateState('compacted');
   }
 
   /**

--- a/src/framework/theme/components/sidebar/sidebar.component.ts
+++ b/src/framework/theme/components/sidebar/sidebar.component.ts
@@ -348,11 +348,17 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
       .subscribe(() => this.compact());
 
     getSidebarState$
-      .pipe(filter(({ tag }) => !this.tag || this.tag === tag))
+      .pipe(
+        filter(({ tag }) => !this.tag || this.tag === tag),
+        takeUntil(this.destroy$),
+      )
       .subscribe(({ observer }) => observer.next(this.state));
 
     getSidebarResponsiveState$
-      .pipe(filter(({ tag }) => !this.tag || this.tag === tag))
+      .pipe(
+        filter(({ tag }) => !this.tag || this.tag === tag),
+        takeUntil(this.destroy$),
+      )
       .subscribe(({ observer }) => observer.next(this.responsiveState));
 
     this.responsiveValueChange$

--- a/src/framework/theme/components/sidebar/sidebar.spec.ts
+++ b/src/framework/theme/components/sidebar/sidebar.spec.ts
@@ -1,8 +1,10 @@
-import { Component, DebugElement } from '@angular/core';
+import { Component, DebugElement, Injectable } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Observable, Subject } from 'rxjs';
+import { pairwise, startWith } from 'rxjs/operators';
 import {
   NbSidebarComponent,
   NbMenuModule,
@@ -11,12 +13,17 @@ import {
   NbMenuComponent,
   NbThemeModule,
   NbMenuItemComponent,
-  NbIconComponent, NbSidebarService,
+  NbIconComponent,
+  NbSidebarService,
+  NbSidebarState,
+  NbMediaBreakpoint,
+  NbThemeService,
+  NbMediaBreakpointsService,
 } from '@nebular/theme';
 
 @Component({
   template: `
-    <nb-sidebar>
+    <nb-sidebar [responsive]="responsive" [state]="state">
       <button id="button-outside-menu"></button>
       <nb-menu [items]="menuItems"></nb-menu>
     </nb-sidebar>
@@ -36,6 +43,32 @@ export class SidebarExpandTestComponent {
       group: true,
     },
   ];
+
+  responsive = false;
+  state: NbSidebarState = 'expanded';
+}
+
+@Injectable()
+export class MockThemeService {
+  private breakpoint$ = new Subject<NbMediaBreakpoint>();
+
+  constructor(private breakpointsService: NbMediaBreakpointsService) {
+  }
+
+  setBreakpointTo(breakpointName: string): void {
+    this.breakpoint$.next(this.breakpointsService.getByName(breakpointName));
+  }
+
+  onMediaQueryChange(): Observable<NbMediaBreakpoint[]> {
+    const breakpoints = this.breakpointsService.getBreakpoints();
+    const largestBreakpoint = breakpoints[breakpoints.length - 1];
+
+    return this.breakpoint$
+      .pipe(
+        startWith({ name: 'unknown', width: undefined }, largestBreakpoint),
+        pairwise(),
+      );
+  }
 }
 
 describe('NbSidebarComponent', () => {
@@ -48,6 +81,10 @@ describe('NbSidebarComponent', () => {
         NbSidebarModule.forRoot(),
         NbMenuModule.forRoot(),
       ],
+      providers: [
+        MockThemeService,
+        { provide: NbThemeService, useExisting: MockThemeService },
+      ],
       declarations: [ SidebarExpandTestComponent ],
     });
   });
@@ -55,12 +92,14 @@ describe('NbSidebarComponent', () => {
   describe('States (expanded, collapsed, compacted)', () => {
     let fixture: ComponentFixture<SidebarExpandTestComponent>;
     let sidebarComponent: NbSidebarComponent;
+    let themeService: MockThemeService;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(SidebarExpandTestComponent);
       fixture.detectChanges();
 
       sidebarComponent = fixture.debugElement.query(By.directive(NbSidebarComponent)).componentInstance;
+      themeService = TestBed.inject(MockThemeService);
     });
 
     it(`should collapse when collapse method called`, () => {
@@ -141,6 +180,49 @@ describe('NbSidebarComponent', () => {
       fixture.detectChanges();
 
       expect(sidebarComponent.compacted).toEqual(true);
+    });
+
+    it('should expand when responsive is set to false', () => {
+      sidebarComponent.responsive = true;
+      sidebarComponent.collapse();
+
+      expect(sidebarComponent.state).toEqual('collapsed');
+
+      sidebarComponent.responsive = false;
+
+      expect(sidebarComponent.state).toEqual('expanded');
+    });
+
+    it('should update state according to the current breakpoint when responsive turns on (update to compacted)', () => {
+      const compactedBreakpoints = sidebarComponent.compactedBreakpoints;
+      const largestCompactedBreakpointName = compactedBreakpoints[compactedBreakpoints.length - 1];
+      themeService.setBreakpointTo(largestCompactedBreakpointName);
+
+      expect(sidebarComponent.state).toEqual('expanded');
+
+      sidebarComponent.responsive = true;
+
+      expect(sidebarComponent.state).toEqual('compacted');
+    });
+
+    it('should update state according to the current breakpoint when responsive turns on (update to collapsed)', () => {
+      themeService.setBreakpointTo(sidebarComponent.collapsedBreakpoints[0]);
+
+      expect(sidebarComponent.state).toEqual('expanded');
+
+      sidebarComponent.responsive = true;
+
+      expect(sidebarComponent.state).toEqual('collapsed');
+    });
+
+    it('should expand when responsive and initial state is in different breakpoint', () => {
+      fixture = TestBed.createComponent(SidebarExpandTestComponent);
+      fixture.componentInstance.responsive = true;
+      fixture.componentInstance.state = 'compacted';
+      fixture.detectChanges();
+      sidebarComponent = fixture.debugElement.query(By.directive(NbSidebarComponent)).componentInstance;
+
+      expect(sidebarComponent.state).toEqual('expanded');
     });
   });
 });


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
568497b is the fix. The sidebar will expand when `responsive` is set to `false`. When `responsive` is set to `true` sidebar will check the current breakpoint to determine the state.
a92bc99 - additional fix to unsubscribe from observables on component destroy.
5608742, 477110e - small fix/refactoring to prevent `stateChange` emission when value didn't change.