### PR TITLE
fix(menu): remove expand icon display when all children are hidden

### DIFF
--- a/src/framework/theme/components/menu/menu-item.component.html
+++ b/src/framework/theme/components/menu/menu-item.component.html
@@ -49,7 +49,7 @@
   <nb-icon class="menu-icon" [config]="menuItem.icon" *ngIf="menuItem.icon"></nb-icon>
   <span class="menu-title">{{ menuItem.title }}</span>
   <ng-container *ngIf="badge" [ngTemplateOutlet]="badgeTemplate"></ng-container>
-  <nb-icon class="expand-state" [icon]="getExpandStateIcon()" pack="nebular-essentials"></nb-icon>
+  <nb-icon *ngIf="hasVisibleChildren()" class="expand-state" [icon]="getExpandStateIcon()" pack="nebular-essentials"></nb-icon>
 </a>
 <ul *ngIf="menuItem.children"
     [class.collapsed]="!(menuItem.children && menuItem.expanded)"

--- a/src/framework/theme/components/menu/menu.component.ts
+++ b/src/framework/theme/components/menu/menu.component.ts
@@ -92,6 +92,17 @@ export class NbMenuItemComponent implements DoCheck, AfterViewInit, OnDestroy {
     this.itemClick.emit(item);
   }
 
+  hasVisibleChildren(): boolean {
+    if (typeof this.menuItem.children !== 'undefined') {
+      for (const child of this.menuItem.children) {
+        if (typeof child.hidden === 'undefined' || (typeof child.hidden === 'boolean' && !child.hidden)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   getExpandStateIcon(): string {
     if (this.menuItem.expanded) {
       return 'chevron-down-outline';

--- a/src/framework/theme/components/menu/menu.spec.ts
+++ b/src/framework/theme/components/menu/menu.spec.ts
@@ -191,6 +191,18 @@ describe('NbMenuItem', () => {
     expect(parentItem.querySelector('ul.menu-items')).not.toBeNull();
   });
 
+  it('should not render the expand icon when all the children are hidden', () => {
+    const { fixture } = createSingleMenuComponent([
+      {
+        title: 'Parent item',
+        expanded: true,
+        children: [{ title: 'Hidden child item', hidden: true }],
+      },
+    ]);
+    const expandIconWrapper = fixture.nativeElement.querySelector('.expand-state');
+    expect(expandIconWrapper).toBeNull();
+  });
+
   it('should expand child menu items', () => {
     const { fixture } = createSingleMenuComponent([
       { title: 'Parent item', expanded: true, children: [{  title: 'Child item' }] },

--- a/src/playground/with-layout/menu/menu-children.component.ts
+++ b/src/playground/with-layout/menu/menu-children.component.ts
@@ -32,6 +32,12 @@ export class MenuChildrenComponent {
     },
     {
       title: 'Shopping Bag',
+      children: [
+        {
+          title: 'Hidden Child',
+          hidden: true,
+        },
+      ],
     },
     {
       title: 'Orders',


### PR DESCRIPTION
 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
When an items has all its children hidden, the expand icon should not appear.
See #2687 for more details.

