### PR TITLE
fix(layout): footer fixed position attribute

### DIFF
--- a/src/framework/theme/components/layout/layout.component.scss
+++ b/src/framework/theme/components/layout/layout.component.scss
@@ -106,6 +106,14 @@
           justify-content: center;
           display: flex;
         }
+
+        &.fixed {
+          position: fixed;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          z-index: 1040;
+        }
       }
     }
   }


### PR DESCRIPTION
The footer fixed attribute did not apply fixed positioning, although the docs in the API say it should.

### Please read and mark the following check list before creating a pull request:

 - [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [X] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
This solves the fact that the "fixed" attribute on the Footer Layout did not apply fixed positioning.
Linked issue: https://github.com/akveo/nebular/issues/237