### PR TITLE
fix(NbCalendarMonthCellComponent): change DataService from private to…

### DIFF
--- a/src/framework/theme/components/calendar-kit/components/calendar-month-picker/calendar-month-cell.component.ts
+++ b/src/framework/theme/components/calendar-kit/components/calendar-month-picker/calendar-month-cell.component.ts
@@ -40,7 +40,7 @@ export class NbCalendarMonthCellComponent<D> implements NbCalendarCell<D, D> {
 
   @Output() select: EventEmitter<D> = new EventEmitter(true);
 
-  constructor(private dateService: NbDateService<D>) {
+  constructor(protected dateService: NbDateService<D>) {
   }
 
   @HostBinding('class.selected') get selected(): boolean {


### PR DESCRIPTION
… protected

Extends can be properly done
Also NbCalendarDayCellComponent and NbCalendarYearCellComponent have dataService as Protected

### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
