### PR TITLE
add role and aria setting for accessibility of toaster

### DIFF
--- a/src/framework/theme/components/toastr/toast.component.html
+++ b/src/framework/theme/components/toastr/toast.component.html
@@ -1,4 +1,9 @@
-<div class="icon-container" *ngIf="hasIcon && icon">
+<div
+  role="alert"
+  aria-live="assertive"
+  class="icon-container"
+  *ngIf="hasIcon && icon"
+>
   <nb-icon [config]="icon"></nb-icon>
 </div>
 <div class="content-container">


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [Y] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [Y] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

The toast Messages do not focus and screen readers do not have access to any message in the toast.

##### To mitigate that 

- a role for [Identification](https://www.w3.org/TR/UNDERSTANDING-WCAG20/consistent-behavior-consistent-functionality.html) for the component.
- since there is no [focus](ttps://www.w3.org/TR/WCAG21/#status-messages ) - adding assistive behavior 
