### PR TITLE
fix(nb-select): no error on reset with mulitple

### DIFF
--- a/src/framework/theme/components/select/select.component.ts
+++ b/src/framework/theme/components/select/select.component.ts
@@ -1024,7 +1024,7 @@ export class NbSelectComponent implements OnChanges, AfterViewInit, AfterContent
 
   protected setActiveOption() {
     if (this.selectionModel.length) {
-      this.keyManager.setActiveItem(this.selectionModel[ 0 ]);
+      this.keyManager.setActiveItem(this.selectionModel[0]);
     } else {
       this.keyManager.setFirstItemActive();
     }
@@ -1156,9 +1156,14 @@ export class NbSelectComponent implements OnChanges, AfterViewInit, AfterContent
    * */
   protected setSelection(value) {
     const isArray: boolean = Array.isArray(value);
+    let formattedValue = value;
 
-    if (this.multiple && !isArray) {
-      throw new Error('Can\'t assign single value if select is marked as multiple');
+    if (this.multiple) {
+      if (value === null || value === undefined) {
+        formattedValue = [];
+      } else if (!isArray) {
+        throw new Error('Can\'t assign single value if select is marked as multiple');
+      }
     }
 
     if (!this.multiple && isArray) {
@@ -1168,10 +1173,10 @@ export class NbSelectComponent implements OnChanges, AfterViewInit, AfterContent
     const previouslySelectedOptions = this.selectionModel;
     this.selectionModel = [];
 
-    if (isArray) {
-      value.forEach(option => this.selectValue(option));
+    if (this.multiple) {
+      formattedValue.forEach(option => this.selectValue(option));
     } else {
-      this.selectValue(value);
+      this.selectValue(formattedValue);
     }
 
     // find options which were selected before and trigger deselect


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [X] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Fixes #1950 

**Before fix:**
form.reset() sets null for each control in form and null is not an array. Error was produced.

**After fix:**
When select is multiple we have additional check on null and undefined (in this case value will be empty array)