### PR TITLE
Add localization of remaining elements in timepicker

### DIFF
--- a/src/framework/theme/components/timepicker/model.ts
+++ b/src/framework/theme/components/timepicker/model.ts
@@ -13,6 +13,9 @@ export interface NbTimepickerLocalizationConfig {
   minutesText: string,
   secondsText: string,
   ampmText: string,
+  timeText: string;
+  applyButtonText: string,
+  currentTimeButtonText: string,
 }
 
 export const NB_DEFAULT_TIMEPICKER_LOCALIZATION_CONFIG: NbTimepickerLocalizationConfig = {
@@ -20,12 +23,15 @@ export const NB_DEFAULT_TIMEPICKER_LOCALIZATION_CONFIG: NbTimepickerLocalization
   minutesText: 'Min',
   secondsText: 'Sec',
   ampmText: 'Am/Pm',
+  timeText: 'Time',
+  applyButtonText: 'ok',
+  currentTimeButtonText: 'now',
 };
 
 export interface NbTimePickerConfig {
   twelveHoursFormat?: boolean,
   format?: string,
-  localization?: NbTimepickerLocalizationConfig,
+  localization?: Partial<NbTimepickerLocalizationConfig>,
 }
 
 export interface NbSelectedTimeModel {

--- a/src/framework/theme/components/timepicker/timepicker.component.html
+++ b/src/framework/theme/components/timepicker/timepicker.component.html
@@ -3,7 +3,7 @@
          class="nb-timepicker-container">
   <nb-card-header class="column-header">
     <ng-container *ngIf="singleColumn; else fullTimeHeadersBlock">
-      <div class="header-cell">Time</div>
+      <div class="header-cell">{{ timeText }}</div>
     </ng-container>
     <ng-template #fullTimeHeadersBlock>
       <div class="header-cell">{{ hoursText }}</div>

--- a/src/framework/theme/components/timepicker/timepicker.component.ts
+++ b/src/framework/theme/components/timepicker/timepicker.component.ts
@@ -151,6 +151,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
    */
   @Input() showFooter: boolean = true;
   @Input() applyButtonText: string;
+  @Input() timeText: string;
   @Input() hoursText: string;
   @Input() minutesText: string;
   @Input() secondsText: string;
@@ -378,10 +379,21 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
       this.twelveHoursFormat = this.dateService.getLocaleTimeFormat().includes('h');
     }
 
-    const localeConfig = { ...NB_DEFAULT_TIMEPICKER_LOCALIZATION_CONFIG, ...config?.localization ?? {} };
-    this.hoursText = localeConfig.hoursText;
-    this.minutesText = localeConfig.minutesText;
-    this.secondsText = localeConfig.secondsText;
-    this.ampmText = localeConfig.ampmText;
+    const {
+      hoursText,
+      minutesText,
+      secondsText,
+      ampmText,
+      timeText,
+      applyButtonText,
+      currentTimeButtonText,
+    } = { ...NB_DEFAULT_TIMEPICKER_LOCALIZATION_CONFIG, ...config?.localization ?? {} };
+    this.hoursText = hoursText;
+    this.minutesText = minutesText;
+    this.secondsText = secondsText;
+    this.ampmText = ampmText;
+    this.timeText = timeText;
+    this.applyButtonText = applyButtonText;
+    this.currentTimeButtonText = currentTimeButtonText;
   }
 }

--- a/src/framework/theme/components/timepicker/timepicker.directive.ts
+++ b/src/framework/theme/components/timepicker/timepicker.directive.ts
@@ -116,8 +116,8 @@ import { NB_DOCUMENT } from '../../theme.options';
  * <input [nbTimepicker]="timepicker" twelveHoursFormat>
  * <nb-timepicker #timepicke [ngModel]="date"></nb-timepicker>
  *
- * You can provide localized versions of the timepicker text via the `localization` property of the config
- * object passed to the `forRoot` or `forChild` methods of the `NbTimepickerModule`:
+ * You can provide localized versions of some or all of the timepicker text via the `localization` property
+ * of the config object passed to the `forRoot` or `forChild` methods of the `NbTimepickerModule`:
  * ```ts
  * @NgModule({
  *   imports: [
@@ -128,6 +128,9 @@ import { NB_DOCUMENT } from '../../theme.options';
  *         minutesText: 'Min',
  *         secondsText: 'Sec',
  *         ampmText: 'Am/Pm',
+ *         timeText: 'Time',
+ *         applyButtonText: "ok",
+ *         currentTimeButtonText: "now",
  *       }
  *     }),
  *   ],


### PR DESCRIPTION
Support for localization of timepicker was added in 8.0.0, but a few elements was missed:
 - The header "Time" when using timepicker in "singleColumn"
 - The button "NOW"
 - The button "OK"

NbTimePickerConfig.localization has been made "Partial" in order to maintain backwards combability. 