### PR TITLE
feat(nb-autocomplete): add scroll on arrow keydown

### DIFF
--- a/src/framework/theme/components/autocomplete/autocomplete.component.html
+++ b/src/framework/theme/components/autocomplete/autocomplete.component.html
@@ -5,6 +5,7 @@
                 role="listbox"
                 [id]="id"
                 [class.empty]="!options?.length"
-                [ngClass]="optionsListClass">
+                [ngClass]="optionsListClass"
+                [scrollTop]="scrollTop">
   <ng-content select="nb-option, nb-option-group"></ng-content>
 </nb-option-list>

--- a/src/framework/theme/components/autocomplete/autocomplete.component.ts
+++ b/src/framework/theme/components/autocomplete/autocomplete.component.ts
@@ -74,6 +74,21 @@ export class NbAutocompleteComponent<T> implements AfterContentInit, OnDestroy {
   }
 
   /**
+   * @docs-private
+   * Current offset from the top to display active option.
+   */
+  _scrollTop: number = 0;
+
+  get scrollTop(): number {
+    return this._scrollTop;
+  }
+
+  set scrollTop(value: number) {
+    this._scrollTop = value;
+    this.cd.detectChanges();
+  }
+
+  /**
    * Returns width of the input.
    * */
   get hostWidth(): number {

--- a/src/framework/theme/components/autocomplete/autocomplete.directive.ts
+++ b/src/framework/theme/components/autocomplete/autocomplete.directive.ts
@@ -38,7 +38,7 @@ import {
   NbKeyManagerActiveItemMode,
 } from '../cdk/a11y/descendant-key-manager';
 import { NbScrollStrategies } from '../cdk/adapter/block-scroll-strategy-adapter';
-import { NbOptionComponent } from '../option/option.component';
+import { NbOptionComponent, _getOptionScrollPosition } from '../option/option.component';
 import { convertToBoolProperty } from '../helpers';
 import { NbAutocompleteComponent } from './autocomplete.component';
 
@@ -395,7 +395,13 @@ export class NbAutocompleteDirective<T> implements OnDestroy, AfterViewInit, Con
           this.handleInputValueUpdate(activeItem.value);
 
         } else {
+          const prevActiveItem = this.keyManager.activeItem;
+
           this.keyManager.onKeydown(event);
+
+          if (this.keyManager.activeItem !== prevActiveItem) {
+            this.scrollToOption(this.keyManager.activeItemIndex || 0);
+          }
         }
       });
 
@@ -449,5 +455,32 @@ export class NbAutocompleteDirective<T> implements OnDestroy, AfterViewInit, Con
 
   protected createScrollStrategy(): NbScrollStrategy {
     return this.overlay.scrollStrategies[this.scrollStrategy]();
+  }
+
+  protected scrollToOption(index: number): void {
+    const autocomplete = this.autocomplete;
+
+    if (autocomplete) {
+      if (index === 0) {
+        this.autocomplete.scrollTop = 0;
+
+        return;
+      }
+
+      const option = autocomplete.options.toArray()[index];
+
+      if (option) {
+        const element = option.hostElement;
+
+        const newScrollPosition = _getOptionScrollPosition(
+          element.offsetTop,
+          element.offsetHeight,
+          autocomplete.scrollTop,
+          this.overlayRef.overlayElement.offsetHeight,
+        );
+
+        this.autocomplete.scrollTop = newScrollPosition;
+      }
+    }
   }
 }

--- a/src/framework/theme/components/option/option-list.component.ts
+++ b/src/framework/theme/components/option/option-list.component.ts
@@ -22,13 +22,15 @@ import { NbPosition } from '../cdk/overlay/overlay-position';
 @Component({
   selector: 'nb-option-list',
   template: `
-    <ul class="option-list">
+    <ul class="option-list" [scrollTop]="scrollTop">
       <ng-content></ng-content>
     </ul>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NbOptionListComponent<T> {
+
+  @Input() scrollTop: number = 0;
 
   @Input() size: NbComponentSize = 'medium';
 

--- a/src/framework/theme/components/option/option.component.ts
+++ b/src/framework/theme/components/option/option.component.ts
@@ -162,6 +162,10 @@ export class NbOptionComponent<T = any> implements OnDestroy, AfterViewInit, NbF
     return this.elementRef.nativeElement.textContent;
   }
 
+  get hostElement() {
+    return this.elementRef.nativeElement;
+  }
+
   // TODO: replace with isShowCheckbox property to control this behaviour outside, issues/1965
   @HostBinding('class.multiple')
   get multiple() {
@@ -253,4 +257,24 @@ export class NbOptionComponent<T = any> implements OnDestroy, AfterViewInit, NbF
     this.cd.markForCheck();
   }
 
+}
+
+/**
+ * Determines the position to which to scroll a panel in order for an option to be into view.
+ * @param optionOffset Offset of the option from the top of the panel.
+ * @param optionHeight Height of the options.
+ * @param currentScrollPosition Current scroll position of the panel.
+ * @param panelHeight Height of the panel.
+ */
+export function _getOptionScrollPosition(optionOffset: number, optionHeight: number,
+  currentScrollPosition: number, panelHeight: number): number {
+  if (optionOffset < currentScrollPosition) {
+    return optionOffset;
+  }
+
+  if (optionOffset + optionHeight > currentScrollPosition + panelHeight) {
+    return Math.max(0, optionOffset - panelHeight + optionHeight);
+  }
+
+  return currentScrollPosition;
 }

--- a/src/playground/with-layout/autocomplete/autocomplete-showcase.component.ts
+++ b/src/playground/with-layout/autocomplete/autocomplete-showcase.component.ts
@@ -21,7 +21,7 @@ export class AutocompleteShowcaseComponent implements OnInit {
   @ViewChild('autoInput') input;
 
   ngOnInit() {
-    this.options = ['Option 1', 'Option 2', 'Option 3'];
+    this.options = Array.from(Array(20).keys()).map((value) => `Option ${value + 1}`);
     this.filteredOptions$ = of(this.options);
   }
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [X] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Fixes #2775 

Added scrollTop prop for nb-option-list
offset calculation based on activeItem from keyManager