### PR TITLE
(fix): fix scss warnings when building nebular

### DIFF
--- a/src/framework/theme/components/layout/_layout.component.theme.scss
+++ b/src/framework/theme/components/layout/_layout.component.theme.scss
@@ -17,12 +17,12 @@
   }
 
   nb-sidebar.fixed {
-    left: calc((100vw - #{nb-theme(layout-window-mode-max-width)}) / 2);
+    left: calc(math.div((100vw - #{nb-theme(layout-window-mode-max-width)}), 2));
   }
 
   .layout .layout-container {
     nb-sidebar.fixed.right {
-      right: calc((100vw - #{nb-theme(layout-window-mode-max-width)}) / 2);
+      right: calc(math.div((100vw - #{nb-theme(layout-window-mode-max-width)}), 2));
     }
 
     nb-sidebar.fixed {
@@ -84,7 +84,7 @@
     }
 
     @media screen and (min-width: nb-theme(layout-window-mode-max-width) + 20px) {
-      $padding-top: nb-theme(layout-window-mode-padding-top) / 4;
+      $padding-top: math.div(nb-theme(layout-window-mode-padding-top), 4);
 
       @include window-mode($padding-top);
 
@@ -96,7 +96,7 @@
     }
 
     @media screen and (min-width: nb-theme(layout-window-mode-max-width) + 150px) {
-      $padding-top: nb-theme(layout-window-mode-padding-top) / 2;
+      $padding-top: math.div(nb-theme(layout-window-mode-padding-top), 2);
 
       @include window-mode($padding-top);
 

--- a/src/framework/theme/components/popover/_popover.component.theme.scss
+++ b/src/framework/theme/components/popover/_popover.component.theme.scss
@@ -4,6 +4,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
+@use 'sass:math';
+
 @mixin nb-popover-theme {
   nb-popover {
     $arrow-size: nb-theme(popover-arrow-size);
@@ -59,19 +61,19 @@
     }
 
     &.nb-overlay-left .arrow {
-      right: calc(-1 * #{$arrow-size} - #{$arrow-size} / 2 + 2px);
-      top: calc(50% - #{$arrow-size / 2});
+      right: calc(-1 * #{$arrow-size} - math.div(#{$arrow-size}, 2) + 2px);
+      top: calc(50% - #{math.div($arrow-size, 2)});
       transform: rotate(90deg);
     }
 
     &.nb-overlay-start-top .arrow {
-      right: calc(-1 * #{$arrow-size} - #{$arrow-size} / 2 + 2px);
+      right: calc(-1 * #{$arrow-size} - math.div(#{$arrow-size}, 2) + 2px);
       bottom: $arrow-size;
       transform: rotate(90deg);
     }
 
     &.nb-overlay-start-bottom .arrow {
-      right: calc(-1 * #{$arrow-size} - #{$arrow-size} / 2 + 2px);
+      right: calc(-1 * #{$arrow-size} - math.div(#{$arrow-size}, 2) + 2px);
       top: $arrow-size;
       transform: rotate(90deg);
     }
@@ -97,19 +99,19 @@
     }
 
     &.nb-overlay-right .arrow {
-      left: calc(-1 * #{$arrow-size} - #{$arrow-size} / 2 + 2px);
-      top: calc(50% - #{$arrow-size / 2});
+      left: calc(-1 * #{$arrow-size} - math.div(#{$arrow-size}, 2) + 2px);
+      top: calc(50% - #{math.div($arrow-size, 2)});
       transform: rotate(270deg);
     }
 
     &.nb-overlay-end-top .arrow {
-      left: calc(-1 * #{$arrow-size} - #{$arrow-size} / 2 + 2px);
+      left: calc(-1 * #{$arrow-size} - math.div(#{$arrow-size}, 2) + 2px);
       bottom: $arrow-size;
       transform: rotate(270deg);
     }
 
     &.nb-overlay-end-bottom .arrow {
-      left: calc(-1 * #{$arrow-size} - #{$arrow-size} / 2 + 2px);
+      left: calc(-1 * #{$arrow-size} - math.div(#{$arrow-size}, 2) + 2px);
       top: $arrow-size;
       transform: rotate(270deg);
     }

--- a/src/framework/theme/components/stepper/_stepper.component.theme.scss
+++ b/src/framework/theme/components/stepper/_stepper.component.theme.scss
@@ -4,6 +4,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
+@use 'sass:math';
+
 @mixin nb-stepper-theme {
 
   nb-stepper {
@@ -11,7 +13,7 @@
     &.horizontal {
       .header .step {
         width: nb-theme(stepper-step-index-width);
-        margin: 0 nb-theme(stepper-step-index-width) / 2;
+        margin: 0 math.div(nb-theme(stepper-step-index-width), 2);
       }
 
       .header .connector {

--- a/src/framework/theme/styles/core/_mixins.scss
+++ b/src/framework/theme/styles/core/_mixins.scss
@@ -4,7 +4,9 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-@mixin nb-scrollbars($fg, $bg, $size, $border-radius: $size / 2) {
+@use 'sass:math';
+
+@mixin nb-scrollbars($fg, $bg, $size, $border-radius: math.div($size, 2)) {
   &::-webkit-scrollbar {
     width: $size;
     height: $size;


### PR DESCRIPTION
fixes issue where the console is filled with sass compiler warnings related to division operator

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

In this PR I fixed some annoying warnings thrown by the sass compiler (version 2.0 onwards) and division operator.