### PR TITLE
fix(nb-rangepicker): improve validators

### DIFF
--- a/src/framework/theme/components/datepicker/datepicker.directive.ts
+++ b/src/framework/theme/components/datepicker/datepicker.directive.ts
@@ -394,8 +394,11 @@ export class NbDatepickerDirective<D> implements OnDestroy, ControlValueAccessor
   protected minValidator(): ValidationErrors | null {
     const config = this.picker.getValidatorConfig();
     const date = this.datepickerAdapter.parse(this.inputValue, this.picker.format);
-    return (!config.min || !date || this.dateService.compareDates(config.min, date) <= 0) ?
-      null : { nbDatepickerMin: { min: config.min, actual: date } };
+
+    // In case nb-rangepicker connected value is an object { min:Date, max: Date }.
+    const checkedDate = (date as any)?.start ?? date;
+    return (!config.min || !checkedDate || this.dateService.compareDates(config.min, checkedDate) <= 0) ?
+      null : { nbDatepickerMin: { min: config.min, actual: checkedDate } };
   }
 
   /**
@@ -404,8 +407,11 @@ export class NbDatepickerDirective<D> implements OnDestroy, ControlValueAccessor
   protected maxValidator(): ValidationErrors | null {
     const config = this.picker.getValidatorConfig();
     const date = this.datepickerAdapter.parse(this.inputValue, this.picker.format);
-    return (!config.max || !date || this.dateService.compareDates(config.max, date) >= 0) ?
-      null : { nbDatepickerMax: { max: config.max, actual: date } };
+
+    // In case nb-rangepicker connected value is an object { min:Date, max: Date }.
+    const checkedDate = (date as any)?.end ?? date;
+    return (!config.max || !checkedDate || this.dateService.compareDates(config.max, checkedDate) >= 0) ?
+      null : { nbDatepickerMax: { max: config.max, actual: checkedDate } };
   }
 
   /**


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [X] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fixes: #2517 

MinValidator and MaxValidator were thinking that value is a Date.
Problem was that for rangePicker its an object with {start: Date, end: Date}.
Modified validators to think about start and end values (P.S. if they exist)