### PR TITLE
fix(moment date service): use locale format by default

### DIFF
--- a/src/framework/moment/services/moment-date.service.ts
+++ b/src/framework/moment/services/moment-date.service.ts
@@ -184,7 +184,7 @@ export class NbMomentDateService extends NbDateService<Moment> {
   }
 
   isValidDateString(date: string, format: string): boolean {
-    return moment(date, format || this.localeData.defaultFormat).isValid();
+    return this.parse(date, format).isValid();
   }
 
   isValidTimeString(date: string, format: string): boolean {

--- a/src/framework/moment/services/moment-date.service.ts
+++ b/src/framework/moment/services/moment-date.service.ts
@@ -184,7 +184,7 @@ export class NbMomentDateService extends NbDateService<Moment> {
   }
 
   isValidDateString(date: string, format: string): boolean {
-    return moment(date, format).isValid();
+    return moment(date, format || this.localeData.defaultFormat).isValid();
   }
 
   isValidTimeString(date: string, format: string): boolean {
@@ -192,7 +192,7 @@ export class NbMomentDateService extends NbDateService<Moment> {
   }
 
   parse(date: string, format: string): Moment {
-    return moment(date, format);
+    return moment(date, format || this.localeData.defaultFormat);
   }
 
   today(): Moment {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

When manually typing the date into the input field, the DatePicker uses the provided DateFormat.

How to use:

```
@NgModule({
  imports: [
    NbDatepickerModule.forRoot(),
    NbMomentDateModule,
    ...
  ],
  providers: [{provide: LOCALE_ID, useValue: 'ru-RU'}],
})
```


Closes #2080