### PR TITLE
feat(window): add component instance property to window ref

### DIFF
--- a/src/framework/theme/components/cdk/overlay/overlay-container.ts
+++ b/src/framework/theme/components/cdk/overlay/overlay-container.ts
@@ -148,7 +148,7 @@ export class NbOverlayContainerComponent {
       this.portalOutlet.detach();
     }
     this.attachStringContent(null);
-    this.isAttached = false
+    this.isAttached = false;
   }
 
   protected createChildInjector(cfr: ComponentFactoryResolver): NbPortalInjector {

--- a/src/framework/theme/components/window/window-ref.ts
+++ b/src/framework/theme/components/window/window-ref.ts
@@ -7,9 +7,11 @@ import { NbWindowConfig, NbWindowState, NbWindowStateChange } from './window.opt
  * The `NbWindowRef` helps to manipulate window after it was created.
  * The window can be dismissed by using `close` method of the windowRef.
  * You can access rendered component as `componentRef` property of the windowRef.
+ * Property `windowContentInstance` contains the instance of the component opened into he window.
  */
-export class NbWindowRef {
+export class NbWindowRef<T = any> {
   componentRef: ComponentRef<NbWindowComponent>;
+  windowContentInstance: T;
 
   protected prevStateValue: NbWindowState;
   protected stateValue: NbWindowState;
@@ -83,6 +85,7 @@ export class NbWindowRef {
 
     this._closed = true;
     this.componentRef.destroy();
+    this.windowContentInstance = null;
     this.stateChange$.complete();
     this.closed$.next();
     this.closed$.complete();

--- a/src/framework/theme/components/window/window-ref.ts
+++ b/src/framework/theme/components/window/window-ref.ts
@@ -7,11 +7,11 @@ import { NbWindowConfig, NbWindowState, NbWindowStateChange } from './window.opt
  * The `NbWindowRef` helps to manipulate window after it was created.
  * The window can be dismissed by using `close` method of the windowRef.
  * You can access rendered component as `componentRef` property of the windowRef.
- * Property `windowContentInstance` contains the instance of the component opened into he window.
+ * Property `windowContentInstance` contains the instance of the component opened into the window.
  */
 export class NbWindowRef<T = any> {
   componentRef: ComponentRef<NbWindowComponent>;
-  windowContentInstance: T;
+  componentInstance: T;
 
   protected prevStateValue: NbWindowState;
   protected stateValue: NbWindowState;
@@ -85,7 +85,7 @@ export class NbWindowRef<T = any> {
 
     this._closed = true;
     this.componentRef.destroy();
-    this.windowContentInstance = null;
+    this.componentInstance = null;
     this.stateChange$.complete();
     this.closed$.next();
     this.closed$.complete();

--- a/src/framework/theme/components/window/window-ref.ts
+++ b/src/framework/theme/components/window/window-ref.ts
@@ -7,7 +7,7 @@ import { NbWindowConfig, NbWindowState, NbWindowStateChange } from './window.opt
  * The `NbWindowRef` helps to manipulate window after it was created.
  * The window can be dismissed by using `close` method of the windowRef.
  * You can access rendered component as `componentRef` property of the windowRef.
- * Property `windowContentInstance` contains the instance of the component opened into the window.
+ * Property `contentInstance` contains the instance of the component opened in the window.
  */
 export class NbWindowRef<T = any> {
   componentRef: ComponentRef<NbWindowComponent>;

--- a/src/framework/theme/components/window/window.component.ts
+++ b/src/framework/theme/components/window/window.component.ts
@@ -167,7 +167,7 @@ export class NbWindowComponent implements OnInit, AfterViewChecked, OnDestroy {
   protected attachComponent() {
     const portal = new NbComponentPortal(this.content as Type<any>, null, null, this.cfr);
     const ref = this.overlayContainer.attachComponentPortal(portal, this.context);
-    this.windowRef.windowContentInstance = ref.instance;
+    this.windowRef.componentInstance = ref.instance;
 
     ref.changeDetectorRef.detectChanges();
   }

--- a/src/framework/theme/components/window/window.component.ts
+++ b/src/framework/theme/components/window/window.component.ts
@@ -167,6 +167,8 @@ export class NbWindowComponent implements OnInit, AfterViewChecked, OnDestroy {
   protected attachComponent() {
     const portal = new NbComponentPortal(this.content as Type<any>, null, null, this.cfr);
     const ref = this.overlayContainer.attachComponentPortal(portal, this.context);
+    this.windowRef.windowContentInstance = ref.instance;
+
     ref.changeDetectorRef.detectChanges();
   }
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Closes #2367 

Added `componentInstance` property to `NbWindowRef` contains the instance of the component opened into he window.

How to use: 
```
// window component
...
onAdd = new EventEmitter();

onButtonClick() {
  this.onAdd.emit();
}
...
```

```
// parent component
...
constructor(private windowService: NbWindowService) {}

openWindow() {
  let windowRef<Component> = this.windowService.open(Component);

  const sub = windowRef.componentInstance.onAdd.subscribe(() => {
    // do something
  });
  windowRef.onClose().subscribe(() => {
    // unsubscribe onAdd
  });
}
...
```
