### PR TITLE
fix(button group): prevent unpress in single mode button group

### DIFF
--- a/src/framework/theme/components/button-group/button-group.component.ts
+++ b/src/framework/theme/components/button-group/button-group.component.ts
@@ -12,7 +12,6 @@ import {
   ContentChildren,
   EventEmitter,
   HostBinding,
-  InjectionToken,
   Input,
   OnChanges,
   Output,
@@ -33,9 +32,6 @@ import {
   NbButtonToggleChange,
   NbButtonToggleDirective,
 } from './button-toggle.directive';
-
-export const NB_BUTTON_GROUP_COMPONENT =
-  new InjectionToken<NbButtonGroupComponent>('NbButtonGroupComponent');
 
 /**
  * `<nb-button-group>` visually groups buttons together and allow to control buttons properties and the state as a
@@ -111,7 +107,6 @@ export const NB_BUTTON_GROUP_COMPONENT =
   template: `
     <ng-content></ng-content>
   `,
-  providers: [{provide: NB_BUTTON_GROUP_COMPONENT, useExisting: NbButtonGroupComponent}],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NbButtonGroupComponent implements OnChanges, AfterContentInit {

--- a/src/framework/theme/components/button-group/button-group.component.ts
+++ b/src/framework/theme/components/button-group/button-group.component.ts
@@ -12,6 +12,7 @@ import {
   ContentChildren,
   EventEmitter,
   HostBinding,
+  InjectionToken,
   Input,
   OnChanges,
   Output,
@@ -27,7 +28,14 @@ import { NbComponentSize } from '../component-size';
 import { NbComponentShape } from '../component-shape';
 import { NbComponentOrCustomStatus } from '../component-status';
 import { NbButton } from '../button/base-button';
-import { NbButtonToggleAppearance, NbButtonToggleChange, NbButtonToggleDirective } from './button-toggle.directive';
+import {
+  NbButtonToggleAppearance,
+  NbButtonToggleChange,
+  NbButtonToggleDirective,
+} from './button-toggle.directive';
+
+export const NB_BUTTON_GROUP_COMPONENT =
+  new InjectionToken<NbButtonGroupComponent>('NbButtonGroupComponent');
 
 /**
  * `<nb-button-group>` visually groups buttons together and allow to control buttons properties and the state as a
@@ -103,6 +111,7 @@ import { NbButtonToggleAppearance, NbButtonToggleChange, NbButtonToggleDirective
   template: `
     <ng-content></ng-content>
   `,
+  providers: [{provide: NB_BUTTON_GROUP_COMPONENT, useExisting: NbButtonGroupComponent}],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NbButtonGroupComponent implements OnChanges, AfterContentInit {

--- a/src/framework/theme/components/button-group/button-toggle.directive.ts
+++ b/src/framework/theme/components/button-group/button-toggle.directive.ts
@@ -125,6 +125,7 @@ export class NbButtonToggleDirective extends NbButton {
 
   @HostListener('click')
   onClick(): void {
+    // Don't remove the pressed state of the button in single-toggle button-groups
     if (this.buttonGroup?.multiple || !this.pressed) {
       this.pressed = !this.pressed;
     }

--- a/src/framework/theme/components/button-group/button-toggle.directive.ts
+++ b/src/framework/theme/components/button-group/button-toggle.directive.ts
@@ -10,9 +10,9 @@ import {
   ElementRef,
   EventEmitter,
   HostBinding,
-  HostListener,
+  HostListener, Inject,
   Input,
-  NgZone,
+  NgZone, Optional,
   Output,
   Renderer2,
 } from '@angular/core';
@@ -21,6 +21,7 @@ import { Observable, Subject } from 'rxjs';
 import { NbStatusService } from '../../services/status.service';
 import { convertToBoolProperty, NbBooleanInput } from '../helpers';
 import { NbButton, NbButtonAppearance } from '../button/base-button';
+import {NB_BUTTON_GROUP_COMPONENT, NbButtonGroupComponent} from './button-group.component';
 
 export type NbButtonToggleAppearance = Exclude<NbButtonAppearance, 'hero'>;
 
@@ -123,10 +124,14 @@ export class NbButtonToggleDirective extends NbButton {
 
   @HostListener('click')
   onClick(): void {
+    if (!this.buttonGroup?.multiple && this.pressed) {
+      return;
+    }
     this.pressed = !this.pressed;
   }
 
   constructor(
+    @Optional() @Inject(NB_BUTTON_GROUP_COMPONENT) protected buttonGroup: NbButtonGroupComponent,
     protected renderer: Renderer2,
     protected hostElement: ElementRef<HTMLElement>,
     protected cd: ChangeDetectorRef,

--- a/src/framework/theme/components/button-group/button-toggle.directive.ts
+++ b/src/framework/theme/components/button-group/button-toggle.directive.ts
@@ -125,10 +125,9 @@ export class NbButtonToggleDirective extends NbButton {
 
   @HostListener('click')
   onClick(): void {
-    if (!this.buttonGroup?.multiple && this.pressed) {
-      return;
+    if (this.buttonGroup?.multiple || !this.pressed) {
+      this.pressed = !this.pressed;
     }
-    this.pressed = !this.pressed;
   }
 
   constructor(

--- a/src/framework/theme/components/button-group/button-toggle.directive.ts
+++ b/src/framework/theme/components/button-group/button-toggle.directive.ts
@@ -10,9 +10,10 @@ import {
   ElementRef,
   EventEmitter,
   HostBinding,
-  HostListener, Inject,
+  HostListener,
   Input,
-  NgZone, Optional,
+  NgZone,
+  Optional,
   Output,
   Renderer2,
 } from '@angular/core';
@@ -21,7 +22,7 @@ import { Observable, Subject } from 'rxjs';
 import { NbStatusService } from '../../services/status.service';
 import { convertToBoolProperty, NbBooleanInput } from '../helpers';
 import { NbButton, NbButtonAppearance } from '../button/base-button';
-import {NB_BUTTON_GROUP_COMPONENT, NbButtonGroupComponent} from './button-group.component';
+import { NbButtonGroupComponent } from './button-group.component';
 
 export type NbButtonToggleAppearance = Exclude<NbButtonAppearance, 'hero'>;
 
@@ -131,12 +132,12 @@ export class NbButtonToggleDirective extends NbButton {
   }
 
   constructor(
-    @Optional() @Inject(NB_BUTTON_GROUP_COMPONENT) protected buttonGroup: NbButtonGroupComponent,
     protected renderer: Renderer2,
     protected hostElement: ElementRef<HTMLElement>,
     protected cd: ChangeDetectorRef,
     protected zone: NgZone,
     protected statusService: NbStatusService,
+    @Optional() protected buttonGroup?: NbButtonGroupComponent,
   ) {
     super(renderer, hostElement, cd, zone, statusService);
   }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Closes #2773 

In `<nb-button-group>` clicking 2 times on the same button don't remove the pressed state (similar to the radio group).
