### PR TITLE
fix(focus trigger strategy): detect click out via activeElement

### DIFF
--- a/src/framework/theme/components/cdk/overlay/overlay-trigger.ts
+++ b/src/framework/theme/components/cdk/overlay/overlay-trigger.ts
@@ -36,6 +36,7 @@ export abstract class NbTriggerStrategyBase implements NbTriggerStrategy {
 
   protected destroyed$ = new Subject();
 
+  // @breaking-change 9.0.0 Change parameter to Element instead of Event
   protected isNotOnHostOrContainer(event: Event): boolean {
     return !this.isOnHost(event) && !this.isOnContainer(event);
   }
@@ -177,8 +178,6 @@ export class NbFocusTriggerStrategy extends NbTriggerStrategyBase {
       /**
        * Event target of `click` could be different from `activeElement`.
        * If during click you return focus to the host, it won't be opened.
-       *
-       * Better to change this function signature in next major version.
        */
       filter(() => this.isNotOnHostOrContainer({ target: this.document.activeElement } as unknown as Event)),
       takeUntil(this.destroyed$),

--- a/src/framework/theme/components/cdk/overlay/overlay-trigger.ts
+++ b/src/framework/theme/components/cdk/overlay/overlay-trigger.ts
@@ -174,7 +174,13 @@ export class NbFocusTriggerStrategy extends NbTriggerStrategyBase {
   protected clickOut$: Observable<Event> = observableFromEvent<Event>(this.document, 'click')
     .pipe(
       filter(() => !!this.container()),
-      filter(event => this.isNotOnHostOrContainer(event)),
+      /**
+       * Event target of `click` could be different from `activeElement`.
+       * If during click you return focus to the host, it won't be opened.
+       *
+       * Better to change this function signature in next major version.
+       */
+      filter(() => this.isNotOnHostOrContainer({ target: this.document.activeElement } as unknown as Event)),
       takeUntil(this.destroyed$),
     );
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Click event is fired after focus in/out, so check of event target could be not `document.activeElement`