### PR TITLE
fix(nb-context-menu): don't hide context menu on item click when noop…

### DIFF
--- a/src/framework/theme/components/context-menu/context-menu.directive.ts
+++ b/src/framework/theme/components/context-menu/context-menu.directive.ts
@@ -15,16 +15,16 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import { filter, takeUntil } from 'rxjs/operators';
-import { Subject } from 'rxjs';
+import {filter, takeUntil} from 'rxjs/operators';
+import {Subject} from 'rxjs';
 
-import { NbDynamicOverlay, NbDynamicOverlayController } from '../cdk/overlay/dynamic/dynamic-overlay';
-import { NbDynamicOverlayHandler } from '../cdk/overlay/dynamic/dynamic-overlay-handler';
-import { NbOverlayConfig, NbOverlayRef } from '../cdk/overlay/mapping';
-import { NbAdjustableConnectedPositionStrategy, NbAdjustment, NbPosition } from '../cdk/overlay/overlay-position';
-import { NbTrigger, NbTriggerValues } from '../cdk/overlay/overlay-trigger';
-import { NbContextMenuComponent } from './context-menu.component';
-import { NbMenuItem, NbMenuService } from '../menu/menu.service';
+import {NbDynamicOverlay, NbDynamicOverlayController} from '../cdk/overlay/dynamic/dynamic-overlay';
+import {NbDynamicOverlayHandler} from '../cdk/overlay/dynamic/dynamic-overlay-handler';
+import {NbOverlayConfig, NbOverlayRef} from '../cdk/overlay/mapping';
+import {NbAdjustableConnectedPositionStrategy, NbAdjustment, NbPosition} from '../cdk/overlay/overlay-position';
+import {NbTrigger, NbTriggerValues} from '../cdk/overlay/overlay-trigger';
+import {NbContextMenuComponent} from './context-menu.component';
+import {NbMenuItem, NbMenuService} from '../menu/menu.service';
 
 export interface NbContextMenuContext {
   items: NbMenuItem[];
@@ -275,7 +275,7 @@ export class NbContextMenuDirective implements NbDynamicOverlayController, OnCha
   private subscribeOnItemClick() {
     this.menuService.onItemClick()
       .pipe(
-        filter(({ tag }) => tag === this.tag),
+        filter(({ tag }) => tag === this.tag && this.trigger !== NbTrigger.NOOP),
         takeUntil(this.destroy$),
       )
       .subscribe(() => this.hide());


### PR DESCRIPTION
… trigger

### Please read and mark the following check list before creating a pull request:

 - [ ] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [ ] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

Closes: #2644 

Context menu is not hiding now on menu-item click when `nbContextMenuTrigger="noop"`.