### PR TITLE
Fix (custom scrollbars) cursor pointer not working on scrollbar thumb

### DIFF
--- a/src/framework/theme/styles/core/_mixins.scss
+++ b/src/framework/theme/styles/core/_mixins.scss
@@ -12,8 +12,11 @@
 
   &::-webkit-scrollbar-thumb {
     background: $fg;
-    cursor: pointer;
     border-radius: $border-radius;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   &::-webkit-scrollbar-track {


### PR DESCRIPTION
Type: 
Fix

Scope: 
Custom Scrollbars

Subject:
I noticed on your custom scrollbars that the cursor: pointer; css property was applied to the ::-webkit-scrollbar-thumb. This will only work if applied to the :hover state

Body: 
This will be my first open source contribution, just trying to give back to the community. I'm strong in css and would like to contribute more when I can