### PR TITLE
chore(dev schematics): don't split declarations under 120 ch 

### DIFF
--- a/tools/dev-schematics/playground-module/add-to-modules.ts
+++ b/tools/dev-schematics/playground-module/add-to-modules.ts
@@ -245,6 +245,13 @@ function multilineDeclarationsArray(tree: Tree, modulePath: Path): void {
   }
 
   const declarationsArray = declarationsNode.initializer as ts.ArrayLiteralExpression;
+
+  const isAlreadyMultiline = declarationsArray.getText().includes('\n');
+  const fitsMaxLineLength = declarationsNode.getFullText().length <= 120; // from prettier config
+  if (isAlreadyMultiline || fitsMaxLineLength) {
+    return;
+  }
+
   const replaces = multilineArrayLiteral(source.getFullText(), declarationsArray);
   applyReplaceChange(tree, modulePath, ...replaces);
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Prevent splitting declarations array on multiple lines while expression fits in 120 characters.