### PR TITLE
chore(ci e2e): use preinstalled Chrome driver

### DIFF
--- a/packages-smoke/e2e/.eslintrc.json
+++ b/packages-smoke/e2e/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": "../.eslintrc.json",
+  "overrides": [
+    {
+      "files": [
+        "*.ts"
+      ],
+      "parserOptions": {
+        "project": [
+          "e2e/tsconfig.e2e.json"
+        ],
+        "createDefaultProgram": true
+      }
+    },
+    {
+      "files": [
+        "*.html"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "./*.js"
+      ],
+      "parserOptions": {
+        "ecmaVersion": 11
+      },
+      "env": {
+        "node": true
+      }
+    }
+  ]
+}

--- a/packages-smoke/e2e/protractor.conf.js
+++ b/packages-smoke/e2e/protractor.conf.js
@@ -1,28 +1,28 @@
+const { join } = require('path');
 const { SpecReporter } = require('jasmine-spec-reporter');
 
 exports.config = {
   allScriptsTimeout: 11000,
-  specs: [
-    './src/**/*.e2e-spec.ts'
-  ],
+  specs: ['./src/**/*.e2e-spec.ts'],
   capabilities: {
-    'browserName': 'chrome',
-    'chromeOptions': {
-      'args': ['--no-sandbox', '--headless', '--disable-dev-shm-usage']
-    }
+    browserName: 'chrome',
+    chromeOptions: {
+      args: ['--no-sandbox', '--headless', '--disable-dev-shm-usage'],
+    },
   },
   directConnect: true,
+  chromeDriver: join(process.env.CHROMEWEBDRIVER, 'chromedriver'),
   baseUrl: 'http://localhost:4200/',
   framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,
-    print: function() {}
+    print: function () {},
   },
   onPrepare() {
     require('ts-node').register({
-      project: require('path').join(__dirname, './tsconfig.e2e.json')
+      project: require('path').join(__dirname, './tsconfig.e2e.json'),
     });
     jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
-  }
+  },
 };


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
Fixes case when downloaded chrome driver version doesn't match installed Chrome version.
Also, adds missing ESLint config file for `packages-smoke/e2e` project to specify `protractor.config.js` environment and pass pre-commit linting.