### PR TITLE
fix(select): select does not display the option if data is dynamic

### DIFF
--- a/src/framework/theme/components/select/select.component.ts
+++ b/src/framework/theme/components/select/select.component.ts
@@ -671,7 +671,7 @@ export class NbSelectComponent
     this.writeValue(value);
   }
   get selected() {
-    return this.multiple ? this.selectionModel.map((o) => o.value) : this.selectionModel[0].value;
+    return this.multiple ? this.selectionModel.map((o) => o.value) : this.selectionModel[0]?.value;
   }
 
   /**
@@ -871,7 +871,7 @@ export class NbSelectComponent
     this.options.changes
       .pipe(
         startWith(this.options),
-        filter(() => this.queue != null && this.canSelectValue()),
+        filter(() => this.queue != null || (this.selected && this.canSelectValue())),
         // Call 'writeValue' when current change detection run is finished.
         // When writing is finished, change detection starts again, since
         // microtasks queue is empty.
@@ -879,7 +879,7 @@ export class NbSelectComponent
         switchMap((options: QueryList<NbOptionComponent>) => from(Promise.resolve(options))),
         takeUntil(this.destroy$),
       )
-      .subscribe(() => this.writeValue(this.queue));
+      .subscribe(() => this.writeValue(this.queue || this.selected));
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/nebular/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:

NbSelect doesn't display the [selected] option if data is dynamic

#2145 
