### PR TITLE
chore(ci): prevent duplicate workflow run

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,5 +1,9 @@
 name: PR check
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   build-packages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
For PRs from repo branches

### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
Narrow push trigger to the master branch. Otherwise PRs from branches in the `akveo/nebular` repository trigger pr-check workflow twice.