### PR TITLE
refactor(sidebar): remove deprecated properties

### DIFF
--- a/src/framework/theme/components/sidebar/sidebar.component.ts
+++ b/src/framework/theme/components/sidebar/sidebar.component.ts
@@ -35,12 +35,9 @@ export type NbSidebarResponsiveState = 'mobile' | 'tablet' | 'pc';
  */
 @Component({
   selector: 'nb-sidebar-header',
-  template: `
-    <ng-content></ng-content>
-  `,
+  template: ` <ng-content></ng-content> `,
 })
-export class NbSidebarHeaderComponent {
-}
+export class NbSidebarHeaderComponent {}
 
 /**
  * Sidebar footer container.
@@ -50,12 +47,9 @@ export class NbSidebarHeaderComponent {
  */
 @Component({
   selector: 'nb-sidebar-footer',
-  template: `
-    <ng-content></ng-content>
-  `,
+  template: ` <ng-content></ng-content> `,
 })
-export class NbSidebarFooterComponent {
-}
+export class NbSidebarFooterComponent {}
 
 /**
  * Layout sidebar component.
@@ -133,8 +127,7 @@ export class NbSidebarFooterComponent {
   selector: 'nb-sidebar',
   styleUrls: ['./sidebar.component.scss'],
   template: `
-    <div class="main-container"
-         [class.main-container-fixed]="containerFixedValue">
+    <div class="main-container" [class.main-container-fixed]="containerFixedValue">
       <ng-content select="nb-sidebar-header"></ng-content>
       <div class="scrollable" (click)="onClick($event)">
         <ng-content></ng-content>
@@ -145,7 +138,6 @@ export class NbSidebarFooterComponent {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NbSidebarComponent implements OnInit, OnDestroy {
-
   protected readonly responsiveValueChange$: Subject<boolean> = new Subject<boolean>();
   protected responsiveState: NbSidebarResponsiveState = 'pc';
 
@@ -319,28 +311,32 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.sidebarService.onToggle()
+    this.sidebarService
+      .onToggle()
       .pipe(
         filter(({ tag }) => !this.tag || this.tag === tag),
         takeUntil(this.destroy$),
       )
       .subscribe(({ compact }) => this.toggle(compact));
 
-    this.sidebarService.onExpand()
+    this.sidebarService
+      .onExpand()
       .pipe(
         filter(({ tag }) => !this.tag || this.tag === tag),
         takeUntil(this.destroy$),
       )
       .subscribe(() => this.expand());
 
-    this.sidebarService.onCollapse()
+    this.sidebarService
+      .onCollapse()
       .pipe(
         filter(({ tag }) => !this.tag || this.tag === tag),
         takeUntil(this.destroy$),
       )
       .subscribe(() => this.collapse());
 
-    this.sidebarService.onCompact()
+    this.sidebarService
+      .onCompact()
       .pipe(
         filter(({ tag }) => !this.tag || this.tag === tag),
         takeUntil(this.destroy$),
@@ -446,7 +442,6 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$),
       )
       .subscribe(([prev, current]: [NbMediaBreakpoint, NbMediaBreakpoint]) => {
-
         const isCollapsed = this.collapsedBreakpoints.includes(current.name);
         const isCompacted = this.compactedBreakpoints.includes(current.name);
 
@@ -495,43 +490,4 @@ export class NbSidebarComponent implements OnInit, OnDestroy {
       this.cd.markForCheck();
     }
   }
-
-  /**
-   * @deprecated Use `responsive` property instead
-   * @breaking-change Remove @8.0.0
-   */
-  toggleResponsive(enabled: boolean) {
-    this.responsive = enabled;
-  }
-  /**
-   * @deprecated Use NbSidebarState type instead
-   * @breaking-change Remove @8.0.0
-   */
-  static readonly STATE_EXPANDED: string = 'expanded';
-  /**
-   * @deprecated Use NbSidebarState type instead
-   * @breaking-change Remove @8.0.0
-   */
-  static readonly STATE_COLLAPSED: string = 'collapsed';
-  /**
-   * @deprecated Use NbSidebarState type instead
-   * @breaking-change Remove @8.0.0
-   */
-  static readonly STATE_COMPACTED: string = 'compacted';
-
-  /**
-   * @deprecated Use NbSidebarResponsiveState type instead
-   * @breaking-change Remove @8.0.0
-   */
-  static readonly RESPONSIVE_STATE_MOBILE: string = 'mobile';
-  /**
-   * @deprecated Use NbSidebarResponsiveState type instead
-   * @breaking-change Remove @8.0.0
-   */
-  static readonly RESPONSIVE_STATE_TABLET: string = 'tablet';
-  /**
-   * @deprecated Use NbSidebarResponsiveState type instead
-   * @breaking-change Remove @8.0.0
-   */
-  static readonly RESPONSIVE_STATE_PC: string = 'pc';
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
BREAKING CHANGE:
`NbSidebarComponent.toggleResponsive` method removed. Toggle `responsive` property.
`NbSidebarComponent`'s `STATE_EXPANDED`, `STATE_COLLAPSED`, `STATE_COMPACTED` static properties removed. Use `NbSidebarState` type values (`'expanded'`, `'collapsed'`, `'compacted'`).
`NbSidebarComponent`'s `RESPONSIVE_STATE_MOBILE`, `RESPONSIVE_STATE_TABLET`, `RESPONSIVE_STATE_PC`  static properties removed. Use `NbSidebarResponsiveState` type values (`'mobile'`, `'tablet'`, `'pc'`).