### PR TITLE
feat: add prebuilt themes with custom properties

### DIFF
--- a/src/framework/auth/styles/prebuilt/components-custom-properties.scss
+++ b/src/framework/auth/styles/prebuilt/components-custom-properties.scss
@@ -1,0 +1,10 @@
+@use '../../../theme/styles/themes';
+@use '../../../theme/styles/theming-variables' as *;
+@use '../../../theme/styles/theming' as *;
+@use '../globals' as *;
+
+$nb-global-styles-on-install: false;
+
+@include nb-install() {
+  @include nb-auth-global();
+}

--- a/src/framework/auth/styles/prebuilt/corporate-custom-properties.scss
+++ b/src/framework/auth/styles/prebuilt/corporate-custom-properties.scss
@@ -4,6 +4,4 @@
 
 $nb-enabled-themes: (corporate);
 
-@include nb-install() {
-  @include nb-auth-global();
-}
+@include nb-install();

--- a/src/framework/auth/styles/prebuilt/cosmic-custom-properties.scss
+++ b/src/framework/auth/styles/prebuilt/cosmic-custom-properties.scss
@@ -4,6 +4,4 @@
 
 $nb-enabled-themes: (cosmic);
 
-@include nb-install() {
-  @include nb-auth-global();
-}
+@include nb-install();

--- a/src/framework/auth/styles/prebuilt/dark-custom-properties.scss
+++ b/src/framework/auth/styles/prebuilt/dark-custom-properties.scss
@@ -4,6 +4,4 @@
 
 $nb-enabled-themes: (dark);
 
-@include nb-install() {
-  @include nb-auth-global();
-}
+@include nb-install();

--- a/src/framework/auth/styles/prebuilt/default-custom-properties.scss
+++ b/src/framework/auth/styles/prebuilt/default-custom-properties.scss
@@ -4,6 +4,4 @@
 
 $nb-enabled-themes: (default);
 
-@include nb-install() {
-  @include nb-auth-global();
-}
+@include nb-install();

--- a/src/framework/bootstrap/styles/prebuilt/components-custom-properties.scss
+++ b/src/framework/bootstrap/styles/prebuilt/components-custom-properties.scss
@@ -1,0 +1,10 @@
+@use '../../../theme/styles/themes';
+@use '../../../theme/styles/theming-variables' as *;
+@use '../../../theme/styles/theming' as *;
+@use '../globals' as *;
+
+$nb-global-styles-on-install: false;
+
+@include nb-install() {
+  @include nb-bootstrap-global();
+}

--- a/src/framework/bootstrap/styles/prebuilt/corporate-custom-properties.scss
+++ b/src/framework/bootstrap/styles/prebuilt/corporate-custom-properties.scss
@@ -10,6 +10,4 @@
 
 $nb-enabled-themes: (corporate);
 
-@include nb-install() {
-  @include nb-bootstrap-global();
-}
+@include nb-install();

--- a/src/framework/bootstrap/styles/prebuilt/cosmic-custom-properties.scss
+++ b/src/framework/bootstrap/styles/prebuilt/cosmic-custom-properties.scss
@@ -10,6 +10,4 @@
 
 $nb-enabled-themes: (cosmic);
 
-@include nb-install() {
-  @include nb-bootstrap-global();
-}
+@include nb-install();

--- a/src/framework/bootstrap/styles/prebuilt/dark-custom-properties.scss
+++ b/src/framework/bootstrap/styles/prebuilt/dark-custom-properties.scss
@@ -10,6 +10,4 @@
 
 $nb-enabled-themes: (dark);
 
-@include nb-install() {
-  @include nb-bootstrap-global();
-}
+@include nb-install();

--- a/src/framework/bootstrap/styles/prebuilt/default-custom-properties.scss
+++ b/src/framework/bootstrap/styles/prebuilt/default-custom-properties.scss
@@ -10,6 +10,4 @@
 
 $nb-enabled-themes: (default);
 
-@include nb-install() {
-  @include nb-bootstrap-global();
-}
+@include nb-install();

--- a/src/framework/theme/styles/_theming-variables.scss
+++ b/src/framework/theme/styles/_theming-variables.scss
@@ -15,6 +15,10 @@ $nb-custom-statuses: () !default;
 $layout-window-mode-max-width: 1920px !default;
 $tabset-tab-text-hide-breakpoint: 36rem !default;
 $route-tabset-tab-text-hide-breakpoint: 36rem !default;
+// If disabled `nb-install` wouldn't produce global theme styles and only install content provided into
+// `nb-install` mixin. Used to generate components themes without global theme styles.
+// Works only when `$nb-enable-css-custom-properties` mode enabled.
+$nb-global-styles-on-install: true !default;
 
 // public variables
 $nb-enable-css-custom-properties: true !default !global;
@@ -32,3 +36,4 @@ $nb-theme: () !global;
 $nb-processed-theme: () !global;
 $nb-theme-export-mode: false !default !global;
 $nb-themes-export: () !global;
+$nb-global-styles-on-install: true !default !global;

--- a/src/framework/theme/styles/core/theming/_install.scss
+++ b/src/framework/theme/styles/core/theming/_install.scss
@@ -121,8 +121,10 @@
 @mixin nb-install-global-with-css-props() {
   @content;
 
-  @each $theme-name in register.nb-get-enabled-themes() {
-    @include nb-install-css-properties($theme-name, register.nb-get-registered-theme($theme-name));
+  @if (theming-variables.$nb-global-styles-on-install) {
+    @each $theme-name in register.nb-get-enabled-themes() {
+      @include nb-install-css-properties($theme-name, register.nb-get-registered-theme($theme-name));
+    }
   }
 }
 

--- a/src/framework/theme/styles/prebuilt/components-custom-properties.scss
+++ b/src/framework/theme/styles/prebuilt/components-custom-properties.scss
@@ -1,0 +1,8 @@
+@use '../theming-variables' as *;
+@use '../all' as *;
+
+$nb-global-styles-on-install: false;
+
+@include nb-install() {
+  @include nb-theme-global();
+}

--- a/src/framework/theme/styles/prebuilt/corporate-custom-properties.scss
+++ b/src/framework/theme/styles/prebuilt/corporate-custom-properties.scss
@@ -1,7 +1,5 @@
-@use '../all';
+@use '../all' as *;
 
 $nb-enabled-themes: (corporate);
 
-@include all.nb-install() {
-  @include all.nb-theme-global();
-}
+@include nb-install();

--- a/src/framework/theme/styles/prebuilt/cosmic-custom-properties.scss
+++ b/src/framework/theme/styles/prebuilt/cosmic-custom-properties.scss
@@ -1,7 +1,5 @@
-@use '../all';
+@use '../all' as *;
 
 $nb-enabled-themes: (cosmic);
 
-@include all.nb-install() {
-  @include all.nb-theme-global();
-}
+@include nb-install();

--- a/src/framework/theme/styles/prebuilt/dark-custom-properties.scss
+++ b/src/framework/theme/styles/prebuilt/dark-custom-properties.scss
@@ -1,7 +1,5 @@
-@use '../all';
+@use '../all' as *;
 
 $nb-enabled-themes: (dark);
 
-@include all.nb-install() {
-  @include all.nb-theme-global();
-}
+@include nb-install();

--- a/src/framework/theme/styles/prebuilt/default-custom-properties.scss
+++ b/src/framework/theme/styles/prebuilt/default-custom-properties.scss
@@ -1,7 +1,5 @@
-@use '../all';
+@use '../all' as *;
 
 $nb-enabled-themes: (default);
 
-@include all.nb-install() {
-  @include all.nb-theme-global();
-}
+@include nb-install();


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
Adds `{auth,bootstrap,theme}/styles/prebuilt/components-custom-properties.scss` to separate theme files from components styles. This way user could include component styles once, and then add one or more theme files that only contain theming properties settings.