### PR TITLE
fix(menu): prevent `menu-submenu-text-color` from being overridden by…

### DIFF
--- a/src/framework/theme/components/menu/_menu.component.theme.scss
+++ b/src/framework/theme/components/menu/_menu.component.theme.scss
@@ -91,13 +91,13 @@
 
     .menu-item > .menu-items > .menu-item {
       background: nb-theme(menu-submenu-background-color);
-      color: nb-theme(menu-submenu-text-color);
 
       a {
         border-color: nb-theme(menu-submenu-item-border-color);
         border-style: nb-theme(menu-submenu-item-border-style);
         border-width: nb-theme(menu-submenu-item-border-width);
         padding: nb-theme(menu-submenu-item-padding);
+        color: nb-theme(menu-submenu-text-color);
       }
 
       a.active {


### PR DESCRIPTION
… `menu-text-color` in custom theme

### Please read and mark the following check list before creating a pull request:

- [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
