### PR TITLE
feat(auth): added firebase apple strategy

### DIFF
--- a/docs/articles/auth/firebase-authentication.md
+++ b/docs/articles/auth/firebase-authentication.md
@@ -2,10 +2,12 @@
 
 `@nebular/firebase-auth` allows authentication in firebase applications with `@nebular/auth`.
 The package provides the following strategies:
-  - `NbFirebasePasswordStrategy` - authentication with email/password
-  - `NbFirebaseGoogleStrategy` - authentication with google accounts
-  - `NbFirebaseFacebookStrategy` - authentication with facebook accounts
-  - `NbFirebaseTwitteStrategy` - authentication with twitter accounts
+
+- `NbFirebasePasswordStrategy` - authentication with email/password
+- `NbFirebaseGoogleStrategy` - authentication with google accounts
+- `NbFirebaseAppleStrategy` - authentication with apple-id
+- `NbFirebaseFacebookStrategy` - authentication with facebook accounts
+- `NbFirebaseTwitteStrategy` - authentication with twitter accounts
 
 `@nebular/auth` package is sponsored by [GO-ER](https://go-er.com) and [What Now Travel](https://whatnow.travel/).
 
@@ -20,12 +22,11 @@ The package provides the following strategies:
   </div>
 </div>
 
- 
 Install Nebular Auth and Nebular Firebase Auth.
- 
- ```sh
-   npm i @nebular/auth @nebular/firebase-auth
- ```
+
+```sh
+  npm i @nebular/auth @nebular/firebase-auth
+```
 
 Import the NbAuthModule with some firebase strategies, in that example we use NbFirebasePasswordStrategy.
 
@@ -37,7 +38,7 @@ import { NbFirebasePasswordStrategy } from '@nebular/firebase-auth';
 @NgModule({
   imports: [
    // ...
-      
+
     NbAuthModule.forRoot({
      strategies: [
        NbFirebasePasswordStrategy.setup({
@@ -49,6 +50,7 @@ import { NbFirebasePasswordStrategy } from '@nebular/firebase-auth';
   ],
 });
 ```
+
 <hr>
 
 ## Authentication with email and password
@@ -56,6 +58,7 @@ import { NbFirebasePasswordStrategy } from '@nebular/firebase-auth';
 Nebular Firebase Auth provides NbFirebasePassword strategy for authentication with email and password.
 
 Strategy settings:
+
  <div class="note note-info">
   <div class="note-title">Note</div>
   <div class="note-body">
@@ -121,27 +124,22 @@ export class NbFirebasePasswordStrategyOptions extends NbAuthStrategyOptions {
   };
   errors?: NbPasswordStrategyMessage = {
     key: 'message',
-    getter: (module: string, res, options: NbFirebasePasswordStrategyOptions) => getDeepFromObject(
-      res,
-      options.errors.key,
-      options[module].defaultErrors,
-    ),
+    getter: (module: string, res, options: NbFirebasePasswordStrategyOptions) =>
+      getDeepFromObject(res, options.errors.key, options[module].defaultErrors),
   };
   messages?: NbPasswordStrategyMessage = {
     key: 'messages',
-    getter: (module: string, res, options: NbFirebasePasswordStrategyOptions) => getDeepFromObject(
-      res.body,
-      options.messages.key,
-      options[module].defaultMessages,
-    ),
+    getter: (module: string, res, options: NbFirebasePasswordStrategyOptions) =>
+      getDeepFromObject(res.body, options.messages.key, options[module].defaultMessages),
   };
 }
 ```
+
 <hr>
 
 ## Social Authentication providers
 
-Nebular Firebase Auth for now provides strategies for authentication with Google, Facebook and Twitter.
+Nebular Firebase Auth for now provides strategies for authentication with Google, Apple, Facebook and Twitter.
 These strategies share the same settings structure and default settings value.
 
 Strategies settings:
@@ -178,6 +176,7 @@ export class NbFirebaseIdentityProviderStrategyOptions extends NbAuthStrategyOpt
   }
 };
 ```
+
 <hr>
 
 ## Complete example
@@ -185,6 +184,6 @@ export class NbFirebaseIdentityProviderStrategyOptions extends NbAuthStrategyOpt
 A complete code example could be found on [GitHub](https://github.com/akveo/nebular/tree/master/src/playground/without-layout/firebase).
 
 And here the playground examples available to play around with
- - [Firebase Nebular Password Example](/example/firebase/password-showcase)
- - [Firebase Nebular Social Authentication Providers Example](/example/firebase/social-auth-showcase)
 
+- [Firebase Nebular Password Example](/example/firebase/password-showcase)
+- [Firebase Nebular Social Authentication Providers Example](/example/firebase/social-auth-showcase)

--- a/src/framework/firebase-auth/firebase-auth.module.ts
+++ b/src/framework/firebase-auth/firebase-auth.module.ts
@@ -4,21 +4,21 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-
 import { NgModule } from '@angular/core';
 
 import { NbFirebasePasswordStrategy } from './strategies/password/firebase-password.strategy';
 import { NbFirebaseGoogleStrategy } from './strategies/google/firebase-google.strategy';
+import { NbFirebaseAppleStrategy } from './strategies/apple/firebase-apple.strategy';
 import { NbFirebaseFacebookStrategy } from './strategies/facebook/firebase-facebook.strategy';
 import { NbFirebaseTwitteStrategy } from './strategies/twitter/firebase-twitter.strategy';
-
 
 @NgModule({
   providers: [
     NbFirebasePasswordStrategy,
     NbFirebaseGoogleStrategy,
+    NbFirebaseAppleStrategy,
     NbFirebaseFacebookStrategy,
     NbFirebaseTwitteStrategy,
   ],
 })
-export class NbFirebaseAuthModule { }
+export class NbFirebaseAuthModule {}

--- a/src/framework/firebase-auth/strategies/apple/firebase-apple.strategy.ts
+++ b/src/framework/firebase-auth/strategies/apple/firebase-apple.strategy.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Akveo. All Rights Reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ */
+
+import { Injectable } from '@angular/core';
+import { from, Observable } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
+import { NbAuthStrategyClass, NbAuthResult, NbAuthStrategyOptions } from '@nebular/auth';
+
+import { NbFirebaseBaseStrategy } from '../base/firebase-base.strategy';
+import { NbFirebaseIdentityProviderStrategyOptions } from '../base/firebase-identity-provider-strategy.options';
+
+import firebase from 'firebase/compat/app';
+import 'firebase/compat/auth';
+
+@Injectable()
+export class NbFirebaseAppleStrategy extends NbFirebaseBaseStrategy {
+  protected defaultOptions: NbFirebaseIdentityProviderStrategyOptions = new NbFirebaseIdentityProviderStrategyOptions();
+
+  static setup(options: NbFirebaseIdentityProviderStrategyOptions): [NbAuthStrategyClass, NbAuthStrategyOptions] {
+    return [NbFirebaseAppleStrategy, options];
+  }
+
+  authenticate(data?: any): Observable<NbAuthResult> {
+    const module = 'authenticate';
+    const provider = new firebase.auth.OAuthProvider('apple.com');
+    const scopes = this.getOption('scopes');
+    scopes.forEach((scope) => provider.addScope(scope));
+    provider.setCustomParameters(this.getOption('customParameters'));
+
+    return from(this.afAuth.signInWithPopup(provider)).pipe(
+      switchMap((res) => this.processSuccess(res, module)),
+      catchError((error) => this.processFailure(error, module)),
+    );
+  }
+}


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:

I added a firebase apple strategy to allow authentication by apple id. This is crucial for platforms which feature an ios app, as apple requires app developers to allow people to use "sign in with apple" if other social logins are allowed as well. Therefore this is an important feature.

As it is not trivial to add the required firebase-settings to the current playground, this MR doesn't feature a playground/unit-tests yet. If you think I should work on that, please point me into the right direction, as the other strategies don't have unit-tests either, as far as I could see.