### PR TITLE
docs(context menu): add nbContextMenuClass description

### DIFF
--- a/src/framework/theme/components/context-menu/context-menu.directive.ts
+++ b/src/framework/theme/components/context-menu/context-menu.directive.ts
@@ -187,6 +187,9 @@ export class NbContextMenuDirective implements NbDynamicOverlayController, OnCha
   trigger: NbTrigger = NbTrigger.CLICK;
   static ngAcceptInputType_trigger: NbTriggerValues;
 
+  /**
+   * Set custom class on context menu, which helps you to customize it using CSS.
+   * */
   @Input('nbContextMenuClass')
   get contextMenuClass(): string {
     return this._contextMenuClass;


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:

Currently the documentation does not show that it is possible to add a custom css class in the Context Menu. This PR solves that.