### PR TITLE
fix(layout): move scroll position update in constructor

### DIFF
--- a/src/framework/theme/components/layout/layout.component.ts
+++ b/src/framework/theme/components/layout/layout.component.ts
@@ -297,6 +297,14 @@ export class NbLayoutComponent implements AfterViewInit, OnDestroy {
         }
       });
 
+    this.scrollService
+      .onGetPosition()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(({ listener }) => {
+        listener.next(this.getScrollPosition());
+        listener.complete();
+      });
+
     if (isPlatformBrowser(this.platformId)) {
       // trigger first time so that after the change we have the initial value
       this.themeService.changeWindowWidth(this.window.innerWidth);
@@ -304,12 +312,6 @@ export class NbLayoutComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit() {
-    this.scrollService.onGetPosition()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(({ listener }) => {
-        listener.next(this.getScrollPosition());
-        listener.complete();
-      });
 
     this.scrollTop.shouldRestore()
       .pipe(filter(


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
NbLayoutScrollService.scrollPositionReq$ may be emited before view init
Update layout scroll logic update identically to 9.0.0