### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/framework/theme/services/color.helper.ts
+++ b/src/framework/theme/services/color.helper.ts
@@ -13,8 +13,8 @@ export class NbColorHelper {
 
     let result = '#';
     for (let i = 1; i < 7; i += 2) {
-      const firstPart = h2d(color1.substr(i, 2));
-      const secondPart = h2d(color2.substr(i, 2));
+      const firstPart = h2d(color1.slice(i, i + 2));
+      const secondPart = h2d(color2.slice(i, i + 2));
       const resultPart = d2h(Math.floor(secondPart + (firstPart - secondPart) * (weight / 100.0)));
       result += ('0' + resultPart).slice(-2);
     }


### PR DESCRIPTION

### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.