### PR TITLE
fix(menu): empty hrefs minor accessibility fix

### DIFF
--- a/src/framework/theme/components/menu/menu-item.component.html
+++ b/src/framework/theme/components/menu/menu-item.component.html
@@ -45,7 +45,8 @@
    [attr.title]="menuItem.title"
    [class.active]="menuItem.selected"
    (mouseenter)="onHoverItem(menuItem)"
-   href="#">
+   role="button"
+   tabindex="0">
   <nb-icon class="menu-icon" [config]="menuItem.icon" *ngIf="menuItem.icon"></nb-icon>
   <span class="menu-title">{{ menuItem.title }}</span>
   <ng-container *ngIf="badge" [ngTemplateOutlet]="badgeTemplate"></ng-container>


### PR DESCRIPTION
Removed href="#" 
Added role="button" and tabindex="0"

### Please read and mark the following check list before creating a pull request:

- [✓] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
This is an Accessibility fix that would help screen-reader users better navigate sites using Nebular's menu component.

**Now:**
Menu items with children are links that point to `#`. This can be confusing for screen-readers who expect the links to act as links that will bring them to another page/section and not buttons.

**With the change:**
Menu items with children will not act as a link but as a button instead. However, changing the element to a button affects the styling, so to keep changes minimal, a role="button" is added instead.

A rather short read about why this change might be useful: https://webaim.org/techniques/hypertext/
