### PR TITLE
fix(timepicker): change position adjustment to "counterclockwise"

### DIFF
--- a/src/framework/theme/components/timepicker/timepicker.directive.ts
+++ b/src/framework/theme/components/timepicker/timepicker.directive.ts
@@ -369,7 +369,7 @@ export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAcce
     .connectedTo(this.hostRef)
     .position(NbPosition.BOTTOM)
     .offset(this.overlayOffset)
-    .adjustment(NbAdjustment.VERTICAL);
+    .adjustment(NbAdjustment.COUNTERCLOCKWISE);
   }
 
   protected getContainer() {


### PR DESCRIPTION
"Counterclockwise" position adjustment prevents timepicker from going outside the window horizontally

Before
![image](https://user-images.githubusercontent.com/23496057/180096808-d57e2fb2-f597-4c4b-a30d-77fdaf394bb5.png)
After
![image](https://user-images.githubusercontent.com/23496057/180096821-5740da92-8800-41c0-8649-8fe161a9bcda.png)
