### PR TITLE
fix(NbRangeAdapterService) :parse and format symbols '-' to ' - ' in NbRangeAdapterService file

### DIFF
--- a/src/framework/theme/components/datepicker/datepicker-adapter.ts
+++ b/src/framework/theme/components/datepicker/datepicker-adapter.ts
@@ -42,7 +42,7 @@ export class NbRangeAdapterService<D> extends NbDatepickerAdapter<NbCalendarRang
   }
 
   parse(range: string, format): NbCalendarRange<D> {
-    const [start, end] = range.split('-').map(subDate => subDate.trim());
+    const [start, end] = range.split(' - ').map(subDate => subDate.trim());
     return {
       start: this.dateService.parse(start, format),
       end: this.dateService.parse(end, format),
@@ -72,7 +72,7 @@ export class NbRangeAdapterService<D> extends NbDatepickerAdapter<NbCalendarRang
   }
 
   isValid(range: string, format: string): boolean {
-    const [start, end] = range.split('-').map(subDate => subDate.trim());
+    const [start, end] = range.split(' - ').map(subDate => subDate.trim());
     return this.dateService.isValidDateString(start, format) && this.dateService.isValidDateString(end, format);
   }
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:

The time format commonly used in China is like '2022-11-11', which will cause the verification to faill.

Convert the symbol ‘-’ to ' - ' to validate the format '2022-12-01 - 2022-12-11'


