### PR TITLE
fix(select-with-autocomplete): fix first render with disabled autocomplete

### DIFF
--- a/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.ts
+++ b/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.ts
@@ -722,8 +722,10 @@ export class NbSelectWithAutocompleteComponent
   }
 
   protected resetAutocompleteInput() {
-    this.optionsAutocompleteInput.nativeElement.value = this.selectionView;
-    this.optionsAutocompleteInputChange.emit('');
+    if (this.optionsAutocompleteInput?.nativeElement) {
+      this.optionsAutocompleteInput.nativeElement.value = this.selectionView;
+      this.optionsAutocompleteInputChange.emit('');
+    }
   }
 
   protected createPositionStrategy(): NbAdjustableConnectedPositionStrategy {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
Fix first render with disabled autocomplete
