### PR TITLE
fix(select-with-autocomplete): improve select open after input changed

### DIFF
--- a/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.html
+++ b/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.html
@@ -42,6 +42,7 @@
     [fieldSize]="size"
     (blur)="trySetTouched()"
     (click)="$event.stopPropagation()"
+    (dblclick)="$event.stopPropagation()"
     (input)="onAutocompleteInputChange($event)"
   />
   <nb-icon nbSuffix icon="chevron-up-outline" pack="nebular-essentials" aria-hidden="true"> </nb-icon>

--- a/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.ts
+++ b/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.ts
@@ -256,6 +256,9 @@ export class NbSelectWithAutocompleteComponent
   }
   set multiple(value: boolean) {
     this._multiple = convertToBoolProperty(value);
+
+    this.updatePositionStrategy();
+    this.updateCurrentKeyManager();
   }
   protected _multiple: boolean = false;
   static ngAcceptInputType_multiple: NbBooleanInput;

--- a/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.ts
+++ b/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.ts
@@ -282,7 +282,7 @@ export class NbSelectWithAutocompleteComponent
    */
   @Input()
   set withOptionsAutocomplete(value: boolean) {
-    this._withOptionsAutocomplete = value;
+    this._withOptionsAutocomplete = convertToBoolProperty(value);
     this.updatePositionStrategy();
     this.updateCurrentKeyManager();
 

--- a/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.ts
+++ b/src/framework/theme/components/select-with-autocomplete/select-with-autocomplete.component.ts
@@ -472,7 +472,7 @@ export class NbSelectWithAutocompleteComponent
       return this.selectionModel.map((option: NbOptionComponent) => option.content).join(', ');
     }
 
-    return this.selectionModel[0]?.content ?? '';
+    return this.selectionModel[0]?.content?.trim() ?? '';
   }
 
   ngOnChanges({ disabled, status, size, fullWidth }: SimpleChanges) {

--- a/src/playground/with-layout/select/select-autocomplete-showcase.component.html
+++ b/src/playground/with-layout/select/select-autocomplete-showcase.component.html
@@ -1,10 +1,12 @@
 <nb-card size="small">
   <nb-card-body>
     <button nbButton (click)="withAutocomplete = !withAutocomplete">Toggle autocomplete: {{ withAutocomplete }}</button>
+    <button nbButton (click)="multiple = !multiple">Toggle multiple: {{ multiple }}</button>
     <nb-select-with-autocomplete
       placeholder="Select Showcase"
       [(selected)]="selectedItem"
       [withOptionsAutocomplete]="withAutocomplete"
+      [multiple]="multiple"
       (optionsAutocompleteInputChange)="filterValue = $event"
     >
       <nb-option value="">Option empty</nb-option>

--- a/src/playground/with-layout/select/select-autocomplete-showcase.component.ts
+++ b/src/playground/with-layout/select/select-autocomplete-showcase.component.ts
@@ -12,6 +12,7 @@ import { Component } from '@angular/core';
 })
 export class SelectAutocompleteShowcaseComponent {
   withAutocomplete = true;
+  multiple = false;
   selectedItem = '2';
   filterValue = '';
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:

- fix opening options after `multiple` changed
- fix setting autocomplete value with spaces at start and end
- fix double-click closing