### PR TITLE
feat: improve date and time picker inputs combination work

### DIFF
--- a/src/framework/theme/components/datepicker/calendar-with-time.component.ts
+++ b/src/framework/theme/components/datepicker/calendar-with-time.component.ts
@@ -178,7 +178,7 @@ export class NbCalendarWithTimeComponent<D> extends NbCalendarComponent<D> imple
   }
 
   showSeconds(): boolean {
-    return this.withSeconds;
+    return this.withSeconds && !this.singleColumn;
   }
 
   isLarge(): boolean {

--- a/src/framework/theme/components/datepicker/calendar-with-time.component.ts
+++ b/src/framework/theme/components/datepicker/calendar-with-time.component.ts
@@ -171,11 +171,8 @@ export class NbCalendarWithTimeComponent<D> extends NbCalendarComponent<D> imple
     this.dateChange.emit(this.dateService.today());
   }
 
-  /**
-   * We don't show seconds with twelve hours format
-   * */
   showSeconds(): boolean {
-    return this.withSeconds && !this.twelveHoursFormat;
+    return this.withSeconds;
   }
 
   isLarge(): boolean {

--- a/src/framework/theme/components/datepicker/calendar-with-time.component.ts
+++ b/src/framework/theme/components/datepicker/calendar-with-time.component.ts
@@ -35,12 +35,15 @@ import { NbTimePickerComponent } from '../timepicker/timepicker.component';
           [showNavigation]="showNavigation"
           [showWeekNumber]="showWeekNumber"
           [weekNumberSymbol]="weekNumberSymbol"
-          (dateChange)="onDateValueChange($event)">
+          (dateChange)="onDateValueChange($event)"
+        >
         </nb-base-calendar>
-        <div class="timepicker-section"
-             [class.size-large]="isLarge()"
-             [class.timepicker-single-column-width]="singleColumn"
-             [class.timepicker-multiple-column-width]="!singleColumn">
+        <div
+          class="timepicker-section"
+          [class.size-large]="isLarge()"
+          [class.timepicker-single-column-width]="singleColumn"
+          [class.timepicker-multiple-column-width]="!singleColumn"
+        >
           <div class="picker-title">{{ title }}</div>
           <nb-timepicker
             (onSelectTime)="onTimeChange($event)"
@@ -49,7 +52,8 @@ import { NbTimePickerComponent } from '../timepicker/timepicker.component';
             [withSeconds]="showSeconds()"
             [showFooter]="false"
             [singleColumn]="singleColumn"
-            [step]="step">
+            [step]="step"
+          >
           </nb-timepicker>
           <ng-container nbPortalOutlet></ng-container>
         </div>
@@ -115,9 +119,10 @@ export class NbCalendarWithTimeComponent<D> extends NbCalendarComponent<D> imple
   @ViewChild(NbPortalOutletDirective) portalOutlet: NbPortalOutletDirective;
   @ViewChild(NbTimePickerComponent) timepicker: NbTimePickerComponent<D>;
 
-  constructor(protected dateService: NbDateService<D>,
-              public cd: ChangeDetectorRef,
-              protected calendarTimeModelService: NbCalendarTimeModelService<D>,
+  constructor(
+    protected dateService: NbDateService<D>,
+    public cd: ChangeDetectorRef,
+    protected calendarTimeModelService: NbCalendarTimeModelService<D>,
   ) {
     super();
   }

--- a/src/framework/theme/components/datepicker/calendar-with-time.component.ts
+++ b/src/framework/theme/components/datepicker/calendar-with-time.component.ts
@@ -49,6 +49,7 @@ import { NbTimePickerComponent } from '../timepicker/timepicker.component';
             (onSelectTime)="onTimeChange($event)"
             [date]="date"
             [twelveHoursFormat]="twelveHoursFormat"
+            [showAmPmLabel]="showAmPmLabel"
             [withSeconds]="showSeconds()"
             [showFooter]="false"
             [singleColumn]="singleColumn"
@@ -82,6 +83,11 @@ export class NbCalendarWithTimeComponent<D> extends NbCalendarComponent<D> imple
    * Defines 12 hours format like '07:00 PM'.
    * */
   @Input() twelveHoursFormat: boolean;
+
+  /**
+   * Defines should show am/pm label if twelveHoursFormat enabled.
+   * */
+  @Input() showAmPmLabel: boolean;
 
   /**
    * Show seconds in timepicker.

--- a/src/framework/theme/components/datepicker/date-timepicker.component.ts
+++ b/src/framework/theme/components/datepicker/date-timepicker.component.ts
@@ -32,9 +32,10 @@ import { NB_DATE_SERVICE_OPTIONS } from './datepicker.directive';
   template: '',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class NbDateTimePickerComponent<D> extends NbBasePickerComponent<D, D, NbCalendarWithTimeComponent<D>>
-                                          implements OnInit {
-
+export class NbDateTimePickerComponent<D>
+  extends NbBasePickerComponent<D, D, NbCalendarWithTimeComponent<D>>
+  implements OnInit
+{
   protected pickerClass: Type<NbCalendarWithTimeComponent<D>> = NbCalendarWithTimeComponent;
 
   get value(): any {
@@ -112,14 +113,16 @@ export class NbDateTimePickerComponent<D> extends NbBasePickerComponent<D, D, Nb
     return this.valueChange as EventEmitter<D>;
   }
 
-  constructor(@Inject(NB_DOCUMENT) document,
-              positionBuilder: NbPositionBuilderService,
-              triggerStrategyBuilder: NbTriggerStrategyBuilderService,
-              overlay: NbOverlayService,
-              cfr: ComponentFactoryResolver,
-              dateService: NbDateService<D>,
-              @Optional() @Inject(NB_DATE_SERVICE_OPTIONS) dateServiceOptions,
-              protected calendarWithTimeModelService: NbCalendarTimeModelService<D>) {
+  constructor(
+    @Inject(NB_DOCUMENT) document,
+    positionBuilder: NbPositionBuilderService,
+    triggerStrategyBuilder: NbTriggerStrategyBuilderService,
+    overlay: NbOverlayService,
+    cfr: ComponentFactoryResolver,
+    dateService: NbDateService<D>,
+    @Optional() @Inject(NB_DATE_SERVICE_OPTIONS) dateServiceOptions,
+    protected calendarWithTimeModelService: NbCalendarTimeModelService<D>,
+  ) {
     super(document, positionBuilder, triggerStrategyBuilder, overlay, cfr, dateService, dateServiceOptions);
   }
 
@@ -141,8 +144,9 @@ export class NbDateTimePickerComponent<D> extends NbBasePickerComponent<D, D, Nb
     if (this.twelveHoursFormat) {
       this.picker.timeFormat = this.dateService.getTwelveHoursFormat();
     } else {
-      this.picker.timeFormat = this.withSeconds ? this.dateService.getTwentyFourHoursFormatWithSeconds() :
-        this.dateService.getTwentyFourHoursFormat();
+      this.picker.timeFormat = this.withSeconds
+        ? this.dateService.getTwentyFourHoursFormatWithSeconds()
+        : this.dateService.getTwentyFourHoursFormat();
     }
     super.patchWithInputs();
 
@@ -169,4 +173,3 @@ export class NbDateTimePickerComponent<D> extends NbBasePickerComponent<D, D, Nb
     }
   }
 }
-

--- a/src/framework/theme/components/datepicker/date-timepicker.component.ts
+++ b/src/framework/theme/components/datepicker/date-timepicker.component.ts
@@ -80,6 +80,19 @@ export class NbDateTimePickerComponent<D>
   static ngAcceptInputType_twelveHoursFormat: NbBooleanInput;
 
   /**
+   * Defines should show am/pm label if twelveHoursFormat enabled.
+   * */
+  @Input()
+  get showAmPmLabel(): boolean {
+    return this._showAmPmLabel;
+  }
+  set showAmPmLabel(value: boolean) {
+    this._showAmPmLabel = convertToBoolProperty(value);
+  }
+  protected _showAmPmLabel: boolean = true;
+  static ngAcceptInputType_showAmPmLabel: NbBooleanInput;
+
+  /**
    * Show seconds in timepicker.
    * Ignored when singleColumn is true.
    * */
@@ -134,6 +147,7 @@ export class NbDateTimePickerComponent<D>
   protected patchWithInputs() {
     this.picker.singleColumn = this.singleColumn;
     this.picker.twelveHoursFormat = this.twelveHoursFormat;
+    this.picker.showAmPmLabel = this.showAmPmLabel;
     this.picker.withSeconds = this.withSeconds;
     this.picker.step = this.step;
     this.picker.title = this.title;

--- a/src/framework/theme/components/datepicker/date-timepicker.component.ts
+++ b/src/framework/theme/components/datepicker/date-timepicker.component.ts
@@ -158,9 +158,10 @@ export class NbDateTimePickerComponent<D>
     if (this.twelveHoursFormat) {
       this.picker.timeFormat = this.dateService.getTwelveHoursFormat();
     } else {
-      this.picker.timeFormat = this.withSeconds
-        ? this.dateService.getTwentyFourHoursFormatWithSeconds()
-        : this.dateService.getTwentyFourHoursFormat();
+      this.picker.timeFormat =
+        this.withSeconds && !this.singleColumn
+          ? this.dateService.getTwentyFourHoursFormatWithSeconds()
+          : this.dateService.getTwentyFourHoursFormat();
     }
     super.patchWithInputs();
 

--- a/src/framework/theme/components/datepicker/datepicker.component.ts
+++ b/src/framework/theme/components/datepicker/datepicker.component.ts
@@ -133,6 +133,8 @@ export abstract class NbBasePicker<D, T, P> extends NbDatepicker<T, D> {
    * */
   abstract showWeekNumber: boolean;
 
+  readonly formatChanged$: Subject<void> = new Subject();
+
   /**
    * Calendar component class that has to be instantiated inside overlay.
    * */
@@ -489,8 +491,14 @@ export class NbBasePickerComponent<D, T, P> extends NbBasePicker<D, T, P> implem
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.format && !changes.format.isFirstChange()) {
-      this.checkFormat();
+    if (changes.format) {
+      if (!changes.format.isFirstChange()) {
+        this.checkFormat();
+      }
+      this.formatChanged$.next();
+    }
+    if (this.picker) {
+      this.patchWithInputs();
     }
   }
 

--- a/src/framework/theme/components/datepicker/datepicker.directive.ts
+++ b/src/framework/theme/components/datepicker/datepicker.directive.ts
@@ -457,8 +457,10 @@ export class NbDatepickerDirective<D> implements OnDestroy, ControlValueAccessor
         takeUntil(this.destroy$),
       )
       .subscribe(([prevFormat, nextFormat]) => {
-        const date = this.datepickerAdapter.parse(this.inputValue, prevFormat);
-        this.writeInput(date);
+        if (this.inputValue) {
+          const date = this.datepickerAdapter.parse(this.inputValue, prevFormat);
+          this.writeInput(date);
+        }
       });
 
     // In case datepicker component placed after the input with datepicker directive,

--- a/src/framework/theme/components/datepicker/datepicker.directive.ts
+++ b/src/framework/theme/components/datepicker/datepicker.directive.ts
@@ -24,8 +24,8 @@ import {
   ValidatorFn,
   Validators,
 } from '@angular/forms';
-import { fromEvent, merge, Observable, Subject } from 'rxjs';
-import { filter, map, take, takeUntil, tap } from 'rxjs/operators';
+import { fromEvent, merge, Observable, Subject, Subscription } from 'rxjs';
+import { distinctUntilChanged, filter, map, pairwise, take, takeUntil, tap } from 'rxjs/operators';
 
 import { NB_DOCUMENT } from '../../theme.options';
 import { NbDateService } from '../calendar-kit/services/date.service';
@@ -113,6 +113,8 @@ export abstract class NbDatepicker<T, D = T> {
   abstract get isShown(): boolean;
 
   abstract get blur(): Observable<void>;
+
+  abstract get formatChanged$(): Observable<void>;
 }
 
 export const NB_DATE_ADAPTER = new InjectionToken<NbDatepickerAdapter<any>>('Datepicker Adapter');
@@ -285,6 +287,8 @@ export class NbDatepickerDirective<D> implements OnDestroy, ControlValueAccessor
     this.setupPicker();
   }
 
+  protected pickerInputsChangedSubscription: Subscription | undefined;
+
   /**
    * Datepicker adapter.
    * */
@@ -443,6 +447,19 @@ export class NbDatepickerDirective<D> implements OnDestroy, ControlValueAccessor
     if (this.inputValue) {
       this.picker.value = this.datepickerAdapter.parse(this.inputValue, this.picker.format);
     }
+
+    this.pickerInputsChangedSubscription?.unsubscribe();
+    this.pickerInputsChangedSubscription = this.picker.formatChanged$
+      .pipe(
+        map(() => this.picker.format),
+        distinctUntilChanged(),
+        pairwise(),
+        takeUntil(this.destroy$),
+      )
+      .subscribe(([prevFormat, nextFormat]) => {
+        const date = this.datepickerAdapter.parse(this.inputValue, prevFormat);
+        this.writeInput(date);
+      });
 
     // In case datepicker component placed after the input with datepicker directive,
     // we can't read `this.picker.format` on first change detection run,

--- a/src/framework/theme/components/timepicker/timepicker.component.html
+++ b/src/framework/theme/components/timepicker/timepicker.component.html
@@ -1,6 +1,4 @@
-<nb-card *nbPortal
-         [class.supports-scrollbar-theming]="!isFirefox()"
-         class="nb-timepicker-container">
+<nb-card *nbPortal [class.supports-scrollbar-theming]="!isFirefox()" class="nb-timepicker-container">
   <nb-card-header class="column-header">
     <ng-container *ngIf="singleColumn; else fullTimeHeadersBlock">
       <div class="header-cell">Time</div>
@@ -19,11 +17,13 @@
         <nb-list-item
           class="list-item"
           [class.selected]="isSelectedFullTimeValue(item)"
-          *ngFor="let item of fullTimeOptions; trackBy: trackBySingleColumnValue.bind(this)">
+          *ngFor="let item of fullTimeOptions; trackBy: trackBySingleColumnValue.bind(this)"
+        >
           <nb-timepicker-cell
             [value]="getFullTimeString(item)"
             [selected]="isSelectedFullTimeValue(item)"
-            (select)="selectFullTime(item)">
+            (select)="selectFullTime(item)"
+          >
           </nb-timepicker-cell>
         </nb-list-item>
       </nb-list>
@@ -34,11 +34,13 @@
         <nb-list-item
           class="list-item"
           [class.selected]="isSelectedHour(item.value)"
-          *ngFor="let item of hoursColumnOptions; trackBy: trackByTimeValues">
+          *ngFor="let item of hoursColumnOptions; trackBy: trackByTimeValues"
+        >
           <nb-timepicker-cell
             [value]="item.text"
             [selected]="isSelectedHour(item.value)"
-            (select)="setHour(item.value)">
+            (select)="setHour(item.value)"
+          >
           </nb-timepicker-cell>
         </nb-list-item>
       </nb-list>
@@ -46,11 +48,13 @@
         <nb-list-item
           class="list-item"
           [class.selected]="isSelectedMinute(item.value)"
-          *ngFor="let item of minutesColumnOptions; trackBy: trackByTimeValues">
+          *ngFor="let item of minutesColumnOptions; trackBy: trackByTimeValues"
+        >
           <nb-timepicker-cell
             [value]="item.text"
             [selected]="isSelectedMinute(item.value)"
-            (select)="setMinute(item.value)">
+            (select)="setMinute(item.value)"
+          >
           </nb-timepicker-cell>
         </nb-list-item>
       </nb-list>
@@ -58,11 +62,13 @@
         <nb-list-item
           class="list-item"
           [class.selected]="isSelectedSecond(item.value)"
-          *ngFor="let item of secondsColumnOptions; trackBy: trackByTimeValues">
+          *ngFor="let item of secondsColumnOptions; trackBy: trackByTimeValues"
+        >
           <nb-timepicker-cell
             [value]="item.text"
             [selected]="isSelectedSecond(item.value)"
-            (select)="setSecond(item.value)">
+            (select)="setSecond(item.value)"
+          >
           </nb-timepicker-cell>
         </nb-list-item>
       </nb-list>
@@ -70,11 +76,13 @@
         <nb-list-item
           class="list-item am-pm-item"
           [class.selected]="isSelectedDayPeriod(dayPeriod)"
-          *ngFor="let dayPeriod of dayPeriodColumnOptions; trackBy: trackByDayPeriod">
+          *ngFor="let dayPeriod of dayPeriodColumnOptions; trackBy: trackByDayPeriod"
+        >
           <nb-timepicker-cell
             [value]="dayPeriod"
             [selected]="isSelectedDayPeriod(dayPeriod)"
-            (select)="changeDayPeriod(dayPeriod)">
+            (select)="changeDayPeriod(dayPeriod)"
+          >
           </nb-timepicker-cell>
         </nb-list-item>
       </nb-list>

--- a/src/framework/theme/components/timepicker/timepicker.component.html
+++ b/src/framework/theme/components/timepicker/timepicker.component.html
@@ -7,7 +7,9 @@
       <div class="header-cell">{{ hoursText }}</div>
       <div class="header-cell">{{ minutesText }}</div>
       <div *ngIf="withSeconds" class="header-cell">{{ secondsText }}</div>
-      <div *ngIf="twelveHoursFormat" class="header-cell">{{ ampmText }}</div>
+      <div *ngIf="twelveHoursFormat" class="header-cell">
+        <ng-template [ngIf]="showAmPmLabel">{{ ampmText }}</ng-template>
+      </div>
     </ng-template>
   </nb-card-header>
 

--- a/src/framework/theme/components/timepicker/timepicker.component.ts
+++ b/src/framework/theme/components/timepicker/timepicker.component.ts
@@ -29,8 +29,8 @@ import {
 } from './model';
 
 interface NbTimePartOption {
-  value: number,
-  text: string,
+  value: number;
+  text: string;
 }
 
 /**
@@ -51,7 +51,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
   hoursColumnOptions: NbTimePartOption[];
   minutesColumnOptions: NbTimePartOption[];
   secondsColumnOptions: NbTimePartOption[];
-  readonly dayPeriodColumnOptions = [ NbDayPeriod.AM, NbDayPeriod.PM ];
+  readonly dayPeriodColumnOptions = [NbDayPeriod.AM, NbDayPeriod.PM];
   hostRef: ElementRef;
   isAM = true;
 
@@ -83,7 +83,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
   }
   set twelveHoursFormat(value: boolean) {
     this._twelveHoursFormat = convertToBoolProperty(value);
-  };
+  }
   protected _twelveHoursFormat: boolean;
   static ngAcceptInputType_twelveHoursFormat: NbBooleanInput;
 
@@ -97,7 +97,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
   }
   set withSeconds(value: boolean) {
     this._withSeconds = convertToBoolProperty(value);
-  };
+  }
   protected _withSeconds: boolean;
   static ngAcceptInputType_withSeconds: NbBooleanInput;
 
@@ -161,14 +161,16 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
    * Emits date when selected.
    * */
   @Output() onSelectTime: EventEmitter<NbSelectedTimePayload<D>> = new EventEmitter<NbSelectedTimePayload<D>>();
-  @ViewChild(NbPortalDirective, {static: true}) portal: NbPortalDirective;
+  @ViewChild(NbPortalDirective, { static: true }) portal: NbPortalDirective;
 
-  constructor(@Inject(NB_TIME_PICKER_CONFIG) protected config: NbTimePickerConfig,
-              protected platformService: NbPlatform,
-              @Inject(LOCALE_ID) locale: string,
-              public cd: ChangeDetectorRef,
-              protected calendarTimeModelService: NbCalendarTimeModelService<D>,
-              protected dateService: NbDateService<D>) {
+  constructor(
+    @Inject(NB_TIME_PICKER_CONFIG) protected config: NbTimePickerConfig,
+    protected platformService: NbPlatform,
+    @Inject(LOCALE_ID) locale: string,
+    public cd: ChangeDetectorRef,
+    protected calendarTimeModelService: NbCalendarTimeModelService<D>,
+    protected dateService: NbDateService<D>,
+  ) {
     this.initFromConfig(this.config);
   }
 
@@ -176,12 +178,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
     this.timeFormat = this.setupTimeFormat();
   }
 
-  ngOnChanges({
-                step,
-                twelveHoursFormat,
-                withSeconds,
-                singleColumn,
-              }: SimpleChanges): void {
+  ngOnChanges({ step, twelveHoursFormat, withSeconds, singleColumn }: SimpleChanges): void {
     this.timeFormat = this.setupTimeFormat();
 
     const isConfigChanged = step || twelveHoursFormat || withSeconds || singleColumn;
@@ -236,7 +233,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
   }
 
   updateValue(date: D): void {
-    this.onSelectTime.emit({time: date});
+    this.onSelectTime.emit({ time: date });
   }
 
   saveValue(): void {
@@ -308,9 +305,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
 
   protected buildColumnOptions(): void {
     this.timeFormat = this.setupTimeFormat();
-    this.fullTimeOptions = this.singleColumn
-      ? this.calendarTimeModelService.getHoursRange(this.step)
-      : [];
+    this.fullTimeOptions = this.singleColumn ? this.calendarTimeModelService.getHoursRange(this.step) : [];
 
     this.hoursColumnOptions = this.generateHours();
     this.minutesColumnOptions = this.generateMinutesOrSeconds();
@@ -327,26 +322,26 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
   protected generateHours(): NbTimePartOption[] {
     if (!this.twelveHoursFormat) {
       return range(24, (v: number) => {
-        return {value: v, text: this.calendarTimeModelService.paddToTwoSymbols(v)};
+        return { value: v, text: this.calendarTimeModelService.paddToTwoSymbols(v) };
       });
     }
 
     if (this.isAM) {
-      return (range(12, (v: number) => {
+      return range(12, (v: number) => {
         const text = v === 0 ? 12 : v;
-        return {value: v, text: this.calendarTimeModelService.paddToTwoSymbols(text)}
-      }));
+        return { value: v, text: this.calendarTimeModelService.paddToTwoSymbols(text) };
+      });
     }
 
-    return (rangeFromTo(12, 24, (v: number) => {
-      const text = v === 12 ? 12 : (v - 12);
-      return {value: v, text: this.calendarTimeModelService.paddToTwoSymbols(text)}
-    }));
+    return rangeFromTo(12, 24, (v: number) => {
+      const text = v === 12 ? 12 : v - 12;
+      return { value: v, text: this.calendarTimeModelService.paddToTwoSymbols(text) };
+    });
   }
 
   protected generateMinutesOrSeconds(): NbTimePartOption[] {
     return range(60, (v: number) => {
-      return {value: v, text: this.calendarTimeModelService.paddToTwoSymbols(v)};
+      return { value: v, text: this.calendarTimeModelService.paddToTwoSymbols(v) };
     });
   }
 
@@ -363,11 +358,17 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
    */
   buildTimeFormat(): string {
     if (this.twelveHoursFormat) {
-      return `${this.withSeconds && !this.singleColumn ? this.dateService.getTwelveHoursFormatWithSeconds()
-        : this.dateService.getTwelveHoursFormat()}`;
+      return `${
+        this.withSeconds && !this.singleColumn
+          ? this.dateService.getTwelveHoursFormatWithSeconds()
+          : this.dateService.getTwelveHoursFormat()
+      }`;
     } else {
-      return `${this.withSeconds && !this.singleColumn ? this.dateService.getTwentyFourHoursFormatWithSeconds()
-        : this.dateService.getTwentyFourHoursFormat()}`;
+      return `${
+        this.withSeconds && !this.singleColumn
+          ? this.dateService.getTwentyFourHoursFormatWithSeconds()
+          : this.dateService.getTwentyFourHoursFormat()
+      }`;
     }
   }
 
@@ -378,7 +379,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
       this.twelveHoursFormat = this.dateService.getLocaleTimeFormat().includes('h');
     }
 
-    const localeConfig = { ...NB_DEFAULT_TIMEPICKER_LOCALIZATION_CONFIG, ...config?.localization ?? {} };
+    const localeConfig = { ...NB_DEFAULT_TIMEPICKER_LOCALIZATION_CONFIG, ...(config?.localization ?? {}) };
     this.hoursText = localeConfig.hoursText;
     this.minutesText = localeConfig.minutesText;
     this.secondsText = localeConfig.secondsText;

--- a/src/framework/theme/components/timepicker/timepicker.component.ts
+++ b/src/framework/theme/components/timepicker/timepicker.component.ts
@@ -44,7 +44,7 @@ interface NbTimePartOption {
   exportAs: 'nbTimepicker',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class NbTimePickerComponent<D> implements OnChanges, OnInit {
+export class NbTimePickerComponent<D> implements OnChanges {
   protected blur$: Subject<void> = new Subject<void>();
 
   fullTimeOptions: D[];
@@ -54,6 +54,8 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
   readonly dayPeriodColumnOptions = [NbDayPeriod.AM, NbDayPeriod.PM];
   hostRef: ElementRef;
   isAM = true;
+
+  timepickerFormatChange$: Subject<void> = new Subject();
 
   /**
    * Emits when timepicker looses focus.
@@ -73,6 +75,8 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
     this._timeFormat = timeFormat;
   }
   protected _timeFormat: string;
+
+  computedTimeFormat: string = this.setupTimeFormat();
 
   /**
    * Defines 12 hours format .
@@ -174,12 +178,12 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
     this.initFromConfig(this.config);
   }
 
-  ngOnInit(): void {
-    this.timeFormat = this.setupTimeFormat();
-  }
-
   ngOnChanges({ step, twelveHoursFormat, withSeconds, singleColumn }: SimpleChanges): void {
-    this.timeFormat = this.setupTimeFormat();
+    const nextTimeFormat = this.setupTimeFormat();
+    if (nextTimeFormat !== this.computedTimeFormat) {
+      this.computedTimeFormat = nextTimeFormat;
+      this.timepickerFormatChange$.next();
+    }
 
     const isConfigChanged = step || twelveHoursFormat || withSeconds || singleColumn;
 
@@ -292,7 +296,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
   }
 
   getFullTimeString(item: D): string {
-    return this.dateService.format(item, this.timeFormat).toUpperCase();
+    return this.dateService.format(item, this.computedTimeFormat).toUpperCase();
   }
 
   isSelectedFullTimeValue(value: D): boolean {
@@ -304,7 +308,7 @@ export class NbTimePickerComponent<D> implements OnChanges, OnInit {
   }
 
   protected buildColumnOptions(): void {
-    this.timeFormat = this.setupTimeFormat();
+    // this.timeFormat = this.setupTimeFormat();
     this.fullTimeOptions = this.singleColumn ? this.calendarTimeModelService.getHoursRange(this.step) : [];
 
     this.hoursColumnOptions = this.generateHours();

--- a/src/framework/theme/components/timepicker/timepicker.component.ts
+++ b/src/framework/theme/components/timepicker/timepicker.component.ts
@@ -326,7 +326,7 @@ export class NbTimePickerComponent<D> implements OnChanges {
 
     this.hoursColumnOptions = this.generateHours();
     this.minutesColumnOptions = this.generateMinutesOrSeconds();
-    this.secondsColumnOptions = this.withSeconds ? this.generateMinutesOrSeconds() : [];
+    this.secondsColumnOptions = this.showSeconds() ? this.generateMinutesOrSeconds() : [];
   }
 
   /**

--- a/src/framework/theme/components/timepicker/timepicker.component.ts
+++ b/src/framework/theme/components/timepicker/timepicker.component.ts
@@ -321,7 +321,6 @@ export class NbTimePickerComponent<D> implements OnChanges {
   }
 
   protected buildColumnOptions(): void {
-    // this.timeFormat = this.setupTimeFormat();
     this.fullTimeOptions = this.singleColumn ? this.calendarTimeModelService.getHoursRange(this.step) : [];
 
     this.hoursColumnOptions = this.generateHours();

--- a/src/framework/theme/components/timepicker/timepicker.component.ts
+++ b/src/framework/theme/components/timepicker/timepicker.component.ts
@@ -92,6 +92,19 @@ export class NbTimePickerComponent<D> implements OnChanges {
   static ngAcceptInputType_twelveHoursFormat: NbBooleanInput;
 
   /**
+   * Defines should show am/pm label if twelveHoursFormat enabled.
+   * */
+  @Input()
+  get showAmPmLabel(): boolean {
+    return this._showAmPmLabel;
+  }
+  set showAmPmLabel(value: boolean) {
+    this._showAmPmLabel = convertToBoolProperty(value);
+  }
+  protected _showAmPmLabel: boolean = true;
+  static ngAcceptInputType_showAmPmLabel: NbBooleanInput;
+
+  /**
    * Show seconds in timepicker.
    * Ignored when singleColumn is true
    * */

--- a/src/framework/theme/components/timepicker/timepicker.directive.ts
+++ b/src/framework/theme/components/timepicker/timepicker.directive.ts
@@ -199,8 +199,10 @@ export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAcce
         takeUntil(this.destroy$),
       )
       .subscribe(([prevFormat, nextFormat]) => {
-        const date = this.dateService.parse(this.inputValue, prevFormat);
-        this.writeValue(date);
+        if (this.inputValue) {
+          const date = this.dateService.parse(this.inputValue, prevFormat);
+          this.writeValue(date);
+        }
       });
   }
   protected _timePickerComponent: NbTimePickerComponent<D>;

--- a/src/framework/theme/components/timepicker/timepicker.directive.ts
+++ b/src/framework/theme/components/timepicker/timepicker.directive.ts
@@ -170,11 +170,13 @@ import { NB_DOCUMENT } from '../../theme.options';
  * */
 @Directive({
   selector: 'input[nbTimepicker]',
-  providers: [{
-    provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => NbTimePickerDirective),
-    multi: true,
-  }],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => NbTimePickerDirective),
+      multi: true,
+    },
+  ],
 })
 export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAccessor {
   /**
@@ -195,7 +197,6 @@ export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAcce
    * */
   @Input() overlayOffset = 8;
 
-
   /**
    * String representation of latest selected date.
    * Updated when value is updated programmatically (writeValue), via timepicker (subscribeOnApplyClick)
@@ -210,10 +211,8 @@ export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAcce
   protected positionStrategy: NbAdjustableConnectedPositionStrategy;
   protected overlayRef: NbOverlayRef;
   protected destroy$: Subject<void> = new Subject<void>();
-  protected onChange: (value: D) => void = () => {
-  };
-  protected onTouched = () => {
-  };
+  protected onChange: (value: D) => void = () => {};
+  protected onTouched = () => {};
   /**
    * Trigger strategy used by overlay.
    * @docs-private
@@ -244,17 +243,18 @@ export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAcce
     return !this.isOpen;
   }
 
-  constructor(@Inject(NB_DOCUMENT) protected document,
-              protected positionBuilder: NbPositionBuilderService,
-              protected hostRef: ElementRef,
-              protected triggerStrategyBuilder: NbTriggerStrategyBuilderService,
-              protected overlay: NbOverlayService,
-              protected cd: ChangeDetectorRef,
-              protected calendarTimeModelService: NbCalendarTimeModelService<D>,
-              protected dateService: NbDateService<D>,
-              protected renderer: Renderer2,
-              @Attribute('placeholder') protected placeholder: string) {
-  }
+  constructor(
+    @Inject(NB_DOCUMENT) protected document,
+    protected positionBuilder: NbPositionBuilderService,
+    protected hostRef: ElementRef,
+    protected triggerStrategyBuilder: NbTriggerStrategyBuilderService,
+    protected overlay: NbOverlayService,
+    protected cd: ChangeDetectorRef,
+    protected calendarTimeModelService: NbCalendarTimeModelService<D>,
+    protected dateService: NbDateService<D>,
+    protected renderer: Renderer2,
+    @Attribute('placeholder') protected placeholder: string,
+  ) {}
 
   /**
    * Returns host input value.
@@ -306,8 +306,10 @@ export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAcce
 
   setupTimepicker() {
     if (this.dateService.getId() === 'native' && isDevMode()) {
-      console.warn('Date.parse does not support parsing time with custom format.' +
-        ' See details here https://akveo.github.io/nebular/docs/components/datepicker/overview#native-parse-issue')
+      console.warn(
+        'Date.parse does not support parsing time with custom format.' +
+          ' See details here https://akveo.github.io/nebular/docs/components/datepicker/overview#native-parse-issue',
+      );
     }
     this.timepicker.setHost(this.hostRef);
     if (this.inputValue) {
@@ -339,18 +341,13 @@ export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAcce
 
   protected createOverlay() {
     const scrollStrategy = this.createScrollStrategy();
-    this.overlayRef = this.overlay.create(
-      {positionStrategy: this.positionStrategy, scrollStrategy});
+    this.overlayRef = this.overlay.create({ positionStrategy: this.positionStrategy, scrollStrategy });
   }
 
   protected subscribeOnTriggers() {
-    this.triggerStrategy.show$
-    .pipe(filter(() => this.isClosed))
-    .subscribe(() => this.show());
+    this.triggerStrategy.show$.pipe(filter(() => this.isClosed)).subscribe(() => this.show());
 
-    this.triggerStrategy.hide$
-    .pipe(filter(() => this.isOpen))
-    .subscribe(() => {
+    this.triggerStrategy.hide$.pipe(filter(() => this.isOpen)).subscribe(() => {
       this.inputValue = this.lastInputValue || '';
       this.hide();
     });
@@ -358,26 +355,30 @@ export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAcce
 
   protected createTriggerStrategy(): NbTriggerStrategy {
     return this.triggerStrategyBuilder
-    .trigger(NbTrigger.FOCUS)
-    .host(this.hostRef.nativeElement)
-    .container(() => this.getContainer())
-    .build();
+      .trigger(NbTrigger.FOCUS)
+      .host(this.hostRef.nativeElement)
+      .container(() => this.getContainer())
+      .build();
   }
 
   protected createPositionStrategy(): NbAdjustableConnectedPositionStrategy {
     return this.positionBuilder
-    .connectedTo(this.hostRef)
-    .position(NbPosition.BOTTOM)
-    .offset(this.overlayOffset)
-    .adjustment(NbAdjustment.COUNTERCLOCKWISE);
+      .connectedTo(this.hostRef)
+      .position(NbPosition.BOTTOM)
+      .offset(this.overlayOffset)
+      .adjustment(NbAdjustment.COUNTERCLOCKWISE);
   }
 
   protected getContainer() {
-    return this.overlayRef && this.isOpen && <ComponentRef<any>>{
-      location: {
-        nativeElement: this.overlayRef.overlayElement,
-      },
-    };
+    return (
+      this.overlayRef &&
+      this.isOpen &&
+      <ComponentRef<any>>{
+        location: {
+          nativeElement: this.overlayRef.overlayElement,
+        },
+      }
+    );
   }
 
   protected createScrollStrategy(): NbScrollStrategy {
@@ -386,21 +387,20 @@ export class NbTimePickerDirective<D> implements AfterViewInit, ControlValueAcce
 
   protected subscribeOnInputChange() {
     fromEvent(this.input, 'input')
-    .pipe(
-      map(() => this.inputValue),
-      takeUntil(this.destroy$),
-    )
-    .subscribe((value: string) => this.handleInputChange(value));
+      .pipe(
+        map(() => this.inputValue),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((value: string) => this.handleInputChange(value));
   }
 
   protected subscribeToBlur() {
     merge(
       this.timepicker.blur,
-      fromEvent(this.input, 'blur').pipe(
-        filter(() => !this.isOpen && this.document.activeElement !== this.input),
-      ),
-    ).pipe(takeUntil(this.destroy$))
-    .subscribe(() => this.onTouched());
+      fromEvent(this.input, 'blur').pipe(filter(() => !this.isOpen && this.document.activeElement !== this.input)),
+    )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.onTouched());
   }
 
   /**


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
- add rerender if any input changed dynamically
- improve work `withSeconds` and `twelveHoursFormat`
- add option for hiding am/pm label