### PR TITLE
Add clientId to to request when calling passwordToken with NbOAuth2AuthStrategy

### DIFF
--- a/src/framework/auth/strategies/oauth2/oauth2-strategy.ts
+++ b/src/framework/auth/strategies/oauth2/oauth2-strategy.ts
@@ -293,6 +293,7 @@ export class NbOAuth2AuthStrategy extends NbAuthStrategy {
       username: username,
       password: password,
       scope: this.getOption('token.scope'),
+      client_id: this.getOption('clientId'),
     };
     return this.urlEncodeParameters(this.cleanParams(this.addCredentialsToParams(params)));
   }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:

When I try to login using OAuth2 Strategy coupled to keycloak client_id is always required for all calls to token endpoint, even if grant_type is password. 
see https://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
And https://wjw465150.gitbooks.io/keycloak-documentation/content/server_admin/topics/sso-protocols/oidc.html section 
Resource Owner Password Credentials Grant (Direct Access Grants) 
