### PR TITLE
Remove padding on nb layout header

### DIFF
--- a/src/framework/theme/styles/themes/_mapping.scss
+++ b/src/framework/theme/styles/themes/_mapping.scss
@@ -59,7 +59,7 @@ $eva-mapping: (
   header-text-font-weight: text-paragraph-font-weight,
   header-text-line-height: text-paragraph-line-height,
   header-height: 4.75rem,
-  header-padding: 1.25rem,
+  header-padding: 0,
   header-shadow: shadow,
   footer-background-color: background-basic-color-1,
   footer-text-color: text-basic-color,

--- a/src/framework/theme/styles/themes/_mapping.scss
+++ b/src/framework/theme/styles/themes/_mapping.scss
@@ -58,7 +58,7 @@ $eva-mapping: (
   header-text-font-size: text-paragraph-font-size,
   header-text-font-weight: text-paragraph-font-weight,
   header-text-line-height: text-paragraph-line-height,
-  header-height: 4.75rem,
+  header-height: auto,
   header-padding: 0,
   header-shadow: shadow,
   footer-background-color: background-basic-color-1,


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
removes padding for corporate css so that layout header will fill the whole width