### PR TITLE
fix(styles): applies nb-for-theme mixin when cssCustomProperties mode is enabled (#3183)

### DIFF
--- a/src/framework/theme/styles/core/theming/_install.scss
+++ b/src/framework/theme/styles/core/theming/_install.scss
@@ -11,10 +11,21 @@
 @use 'register';
 
 @mixin nb-for-theme($name) {
-  @if (theming-variables.$nb-theme-name == $name) {
-    @content;
+  @if (theming-variables.$nb-enable-css-custom-properties) {
+    @each $theme-name in register.nb-get-enabled-themes() {
+      @if ($theme-name == $name) {
+        .nb-theme-#{$theme-name} {
+          @content;
+        }
+      }
+    }
+  } @else {
+    @if (theming-variables.$nb-theme-name == $name) {
+      @content;
+    }
   }
 }
+
 
 @mixin nb-for-themes($names...) {
   @each $name in $names {


### PR DESCRIPTION
Copied from https://github.com/akveo/nebular/pull/3185 pull request (since it's been more than a year and the issue still persists)

#### Short description of what this resolves:

when nb-enable-css-custom-properties is enabled nb-for-theme mixin doesn't work, this PR fixes that.