### PR TITLE
fix(NbTreeGrid): Add a provide for CDK_TABLE

### DIFF
--- a/src/framework/theme/components/tree-grid/tree-grid.component.ts
+++ b/src/framework/theme/components/tree-grid/tree-grid.component.ts
@@ -21,6 +21,7 @@ import {
   Optional,
   SkipSelf,
 } from '@angular/core';
+import { CDK_TABLE } from '@angular/cdk/table';
 import { fromEvent, merge, Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 
@@ -143,6 +144,7 @@ import { NbColumnsService } from './tree-grid-columns.service';
   styleUrls: ['./tree-grid.component.scss'],
   providers: [
     { provide: NB_TREE_GRID, useExisting: NbTreeGridComponent },
+    { provide: CDK_TABLE, useExisting: NbTreeGridComponent },
     NbColumnsService,
     ...NB_TABLE_PROVIDERS,
   ],


### PR DESCRIPTION
Since Angular 17.1.0 and above the NbTreeGrid component wasn't working due to this missing CDK_TABLE provider and was giving this error: NullInjectorError: No provider for InjectionToken CDK_TABLE!

### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
This fixes the issue where we get a NullInjectorError: No provider for InjectionToken CDK_TABLE! while using Nebular 13 & 14 in combination with Angular 17.1.0 and above. See issue: https://github.com/akveo/nebular/issues/3241