### PR TITLE
feat(NbDialogService): support passing values to input/model signals

### DIFF
--- a/src/framework/theme/components/dialog/dialog-config.ts
+++ b/src/framework/theme/components/dialog/dialog-config.ts
@@ -4,10 +4,18 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-import { InjectionToken, ViewContainerRef } from '@angular/core';
+import { InjectionToken, InputSignal, Signal, ViewContainerRef } from '@angular/core';
 
 
 export const NB_DIALOG_CONFIG = new InjectionToken<NbDialogConfig>('Default dialog options');
+
+type DialogData<T> = {
+  [K in keyof T]: ExtractInputSignalType<T[K]>;
+};
+
+type ExtractInputSignalType<Type> = Type extends InputSignal<infer X> ? X : ExcludeSignal<Type>;
+
+type ExcludeSignal<Type> = Type extends Signal<unknown> ? never : Type;
 
 /**
  * Describes all available options that may be passed to the NbDialogService.
@@ -56,7 +64,7 @@ export class NbDialogConfig<D = any> {
    */
   viewContainerRef: ViewContainerRef;
 
-  context: D;
+  context: DialogData<D>;
 
   constructor(config: Partial<NbDialogConfig>) {
     Object.assign(this, config);

--- a/src/framework/theme/components/dialog/dialog.service.spec.ts
+++ b/src/framework/theme/components/dialog/dialog.service.spec.ts
@@ -1,4 +1,4 @@
-import { Component, NgModule, Injectable } from '@angular/core';
+import { Component, computed, Injectable, input, NgModule } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import {
@@ -27,8 +27,23 @@ export class NbViewportRulerMockAdapter extends NbViewportRulerAdapter {
 })
 class NbTestDialogComponent {}
 
+@Component({
+  selector: 'nb-signal-input-test-dialog',
+  template: `
+    <span class="test-input">{{ value }}</span>
+    <span class="test-input-signal"> {{ number() }}</span>
+    <span class="test-computed-signal">{{ squared() }}</span>
+  `,
+  standalone: false,
+})
+class NbSignalInputTestDialogComponent {
+  value: number;
+  number = input<number>(0);
+  squared = computed(() => this.number() * this.number());
+}
+
 @NgModule({
-  declarations: [NbTestDialogComponent],
+  declarations: [NbTestDialogComponent, NbSignalInputTestDialogComponent],
 })
 class NbTestDialogModule {}
 
@@ -158,5 +173,41 @@ describe('dialog-service', () => {
     document.dispatchEvent(new KeyboardEvent('keyup', <any>{ keyCode: 27 }));
     tick(500);
     expect(queryBackdrop()).toBeTruthy();
+  }));
+
+  it('should display regular inputs', fakeAsync(() => {
+    const ref = dialog.open(NbSignalInputTestDialogComponent, {
+      context: {
+        value: 10,
+      },
+    });
+    tick();
+    const el = ref.componentRef.location.nativeElement.querySelector('.test-input');
+    expect(el).toBeTruthy();
+    expect(el.textContent.trim()).toEqual('10');
+  }));
+
+  it('should display signal inputs', fakeAsync(() => {
+    const ref = dialog.open(NbSignalInputTestDialogComponent, {
+      context: {
+        number: 10,
+      },
+    });
+    tick();
+    const el = ref.componentRef.location.nativeElement.querySelector('.test-input-signal');
+    expect(el).toBeTruthy();
+    expect(el.textContent.trim()).toEqual('10');
+  }));
+
+  it('should derive computed signals from input signals', fakeAsync(() => {
+    const ref = dialog.open(NbSignalInputTestDialogComponent, {
+      context: {
+        number: 10,
+      },
+    });
+    tick();
+    const el = ref.componentRef.location.nativeElement.querySelector('.test-computed-signal');
+    expect(el).toBeTruthy();
+    expect(el.textContent.trim()).toEqual('100');
   }));
 });

--- a/src/framework/theme/components/dialog/dialog.service.ts
+++ b/src/framework/theme/components/dialog/dialog.service.ts
@@ -4,7 +4,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-import { Inject, Injectable, Injector, TemplateRef, Type } from '@angular/core';
+import { Inject, Injectable, Injector, signal, TemplateRef, Type } from '@angular/core';
 import { fromEvent as observableFromEvent } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
@@ -20,6 +20,7 @@ import { NB_DOCUMENT } from '../../theme.options';
 import { NB_DIALOG_CONFIG, NbDialogConfig } from './dialog-config';
 import { NbDialogRef } from './dialog-ref';
 import { NbDialogContainerComponent } from './dialog-container';
+import { SIGNAL } from '@angular/core/primitives/signals';
 
 
 /**
@@ -211,7 +212,15 @@ export class NbDialogService {
       dialogRef.componentRef = container.attachComponentPortal(portal);
 
       if (config.context) {
-        Object.assign(dialogRef.componentRef.instance, { ...config.context })
+        for (const [key, value] of Object.entries({...config.context})) {
+          const instance = dialogRef.componentRef.instance; 
+          const member = instance[key];
+          if (typeof member === 'function' && member[SIGNAL] !== undefined) {
+            instance[key] = signal(value).asReadonly();
+          } else {
+            instance[key] = value;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This makes an exception for input and model signals in the DialogConfig context, so the typehint will show as the type of the signal's value, but internally it will create a signal with the passed value. Technically these will just be readonly signals instead of input or model signals, but since components used as a dialog do not support regular outputs anyway, it should not matter. When used in a regular context the input signal will not be overwritten and work as usual.

### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:
closes https://github.com/akveo/nebular/issues/3256 (I would not classify this as a bug but a missing feature instead)