### PR TITLE
fix: remove obsolete vendor-prefixed and IE-specific CSS

### DIFF
--- a/docs/app/@theme/styles/_common.scss
+++ b/docs/app/@theme/styles/_common.scss
@@ -35,7 +35,6 @@
     height: 1px;
     width: 1px;
     overflow: hidden;
-    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
     clip: rect(1px, 1px, 1px, 1px);
   }
 }

--- a/docs/app/@theme/styles/styles.scss
+++ b/docs/app/@theme/styles/styles.scss
@@ -36,8 +36,6 @@
 }
 
 body {
-  scrollbar-face-color: rgba(0, 0, 0, 0.3);
-  scrollbar-track-color: rgba(255, 255, 255, 0.7);
   min-width: 320px !important;
   -webkit-font-smoothing: antialiased;
 }

--- a/docs/app/blocks/components/live-example-block/live-example-block.component.scss
+++ b/docs/app/blocks/components/live-example-block/live-example-block.component.scss
@@ -83,11 +83,6 @@
       transform: translate(-50%, -50%);
     }
 
-    /* Target IE9 - IE11 */
-    select::-ms-expand {
-      display: none;
-    }
-
     select {
       font-size: 0.875rem;
       appearance: none;
@@ -120,7 +115,6 @@
 
   .iframe-container {
     overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   iframe {
@@ -144,12 +138,12 @@
     transform: translate(-50%, -50%);
   }
 
-  @-webkit-keyframes rotation {
+  @keyframes rotation {
     from {
-      -webkit-transform: rotate(0deg);
+      transform: rotate(0deg);
     }
     to {
-      -webkit-transform: rotate(359deg);
+      transform: rotate(359deg);
     }
   }
 

--- a/src/framework/bootstrap/styles/_modals.scss
+++ b/src/framework/bootstrap/styles/_modals.scss
@@ -60,7 +60,6 @@
 
   .modal-body {
     flex: 1;
-    -ms-flex: 1 1 auto;
     overflow: auto;
     padding: nb-theme(card-padding);
     position: relative;

--- a/src/framework/theme/components/accordion/_accordion.component.theme.scss
+++ b/src/framework/theme/components/accordion/_accordion.component.theme.scss
@@ -73,7 +73,6 @@
 
   nb-accordion-item-body .item-body {
     flex: 1;
-    -ms-flex: 1 1 auto;
     overflow: auto;
     padding: nb-theme(accordion-padding);
     position: relative;

--- a/src/framework/theme/components/card/_card.component.theme.scss
+++ b/src/framework/theme/components/card/_card.component.theme.scss
@@ -83,7 +83,6 @@
 
   nb-card-body {
     flex: 1;
-    -ms-flex: 1 1 auto;
     overflow: auto;
     padding: nb-theme(card-padding);
     position: relative;

--- a/src/framework/theme/components/layout/_layout.component.theme.scss
+++ b/src/framework/theme/components/layout/_layout.component.theme.scss
@@ -55,7 +55,6 @@
 
     @include media-breakpoint-down(sm) {
       overflow-y: scroll;
-      -webkit-overflow-scrolling: touch;
     }
   }
 

--- a/src/framework/theme/components/layout/layout.component.scss
+++ b/src/framework/theme/components/layout/layout.component.scss
@@ -38,7 +38,6 @@
   .layout-container {
     display: flex;
     flex: 1;
-    -ms-flex: 1 1 auto;
     flex-direction: row;
 
     ::ng-deep nb-sidebar {
@@ -65,7 +64,6 @@
     .content {
       display: flex;
       flex: 1;
-      -ms-flex: 1 1 auto;
       flex-direction: column;
       min-width: 0;
 
@@ -79,7 +77,6 @@
       .columns {
         display: flex;
         flex: 1;
-        -ms-flex: 1 1 auto;
         flex-direction: row;
         width: 100%;
 

--- a/src/framework/theme/components/search/_search.component.theme.scss
+++ b/src/framework/theme/components/search/_search.component.theme.scss
@@ -34,10 +34,6 @@
         &::placeholder {
           color: nb-theme(search-placeholder-text-color);
         }
-
-        &::-ms-clear {
-          display: none;
-        }
       }
     }
 

--- a/src/framework/theme/components/sidebar/_sidebar.component.theme.scss
+++ b/src/framework/theme/components/sidebar/_sidebar.component.theme.scss
@@ -27,10 +27,8 @@
       padding: nb-theme(sidebar-padding);
       position: relative;
 
-      -webkit-transform: translate3d(0, 0, 0); // ios optimisation
       @include media-breakpoint-down(sm) {
         overflow-y: scroll;
-        -webkit-overflow-scrolling: touch;
       }
 
       @include nb-scrollbars(

--- a/src/framework/theme/components/tabset/tabset.component.scss
+++ b/src/framework/theme/components/tabset/tabset.component.scss
@@ -15,7 +15,6 @@
 
   ::ng-deep nb-tab {
     flex: 1;
-    -ms-flex: 1 1 auto;
     overflow: auto;
     display: none;
     &.content-active {

--- a/src/framework/theme/styles/core/_mixins.scss
+++ b/src/framework/theme/styles/core/_mixins.scss
@@ -26,13 +26,6 @@
   &::-webkit-scrollbar-corner {
     background: $bg;
   }
-
-  & {
-    // TODO: remove
-    // For Internet Explorer
-    scrollbar-face-color: $fg;
-    scrollbar-track-color: $bg;
-  }
 }
 
 @mixin nb-headings($from: 1, $to: 6) {
@@ -70,7 +63,7 @@
 }
 
 @mixin install-thumb() {
-  $thumb-selectors: ('::-webkit-slider-thumb' '::-moz-range-thumb' '::-ms-thumb');
+  $thumb-selectors: ('::-webkit-slider-thumb' '::-moz-range-thumb');
 
   @each $selector in $thumb-selectors {
     &#{$selector} {
@@ -82,7 +75,7 @@
 }
 
 @mixin install-track() {
-  $thumb-selectors: ('::-webkit-slider-runnable-track' '::-moz-range-track' '::-ms-track');
+  $thumb-selectors: ('::-webkit-slider-runnable-track' '::-moz-range-track');
 
   @each $selector in $thumb-selectors {
     &#{$selector} {
@@ -94,9 +87,7 @@
 }
 
 @mixin install-placeholder($color, $font-size, $opacity: 1) {
-  $placeholder-selectors: (
-    '::-webkit-input-placeholder' '::-moz-placeholder' ':-moz-placeholder' ':-ms-input-placeholder'
-  );
+  $placeholder-selectors: ('::-webkit-input-placeholder' '::-moz-placeholder' ':-moz-placeholder');
 
   &::placeholder {
     @include placeholder($color, $font-size, $opacity);
@@ -143,22 +134,10 @@
       $animations: #{$animations + ', '};
     }
   }
-  -webkit-animation: $animations;
-  -moz-animation: $animations;
-  -o-animation: $animations;
   animation: $animations;
 }
 
 @mixin keyframes($animationName) {
-  @-webkit-keyframes #{$animationName} {
-    @content;
-  }
-  @-moz-keyframes #{$animationName} {
-    @content;
-  }
-  @-o-keyframes #{$animationName} {
-    @content;
-  }
   @keyframes #{$animationName} {
     @content;
   }

--- a/src/framework/theme/styles/global/_styles.scss
+++ b/src/framework/theme/styles/global/_styles.scss
@@ -1,8 +1,8 @@
-.visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+.visually-hidden {
+  /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
   position: absolute !important;
   height: 1px;
   width: 1px;
   overflow: hidden;
-  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
   clip: rect(1px, 1px, 1px, 1px);
 }

--- a/src/playground/styles/styles.scss
+++ b/src/playground/styles/styles.scss
@@ -13,8 +13,6 @@
 }
 
 body {
-  scrollbar-face-color: rgba(0, 0, 0, 0.3);
-  scrollbar-track-color: rgba(255, 255, 255, 0.7);
   min-width: 320px;
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/nebular/blob/master/CONTRIBUTING.md) guide.

#### Short description of what this resolves:

Remove vendor-prefixed CSS that is no longer needed for modern browsers:
- Remove `-webkit-`, `-moz-`, `-o-` prefixed `@keyframes` and `animation` properties from the keyframes/animation mixins
- Replace `@-webkit-keyframes` with standard `@keyframes` in live-example-block
- Replace `-webkit-transform` with standard `transform` in keyframes
- Remove `-webkit-overflow-scrolling: touch` (deprecated since iOS 13)
- Remove `-webkit-transform: translate3d(0,0,0)` iOS GPU hack

Remove IE-specific CSS (IE support dropped in Nebular v9.0.0):
- Remove `-ms-flex: 1 1 auto` fallbacks from layout, card, accordion, tabset, and modal components
- Remove `::-ms-clear`, `::-ms-expand` pseudo-elements
- Remove `::-ms-thumb`, `::-ms-track`, `:-ms-input-placeholder` from SCSS selector mixins
- Remove IE scrollbar properties (`scrollbar-face-color`, `scrollbar-track-color`)
- Remove IE6/IE7 `clip: rect()` fallbacks (keep standard comma-separated syntax)

The vendor-prefixed `@keyframes` rules also caused build warnings with Angular's critical CSS inliner ([beasties](https://github.com/danielroe/beasties)), which fails to parse percentage selectors inside `-moz-keyframes` and `-o-keyframes` at-rules.